### PR TITLE
Folder rename crash fix

### DIFF
--- a/GloryEngine/GloryEditor/ContentBrowserItem.cpp
+++ b/GloryEngine/GloryEditor/ContentBrowserItem.cpp
@@ -141,6 +141,8 @@ namespace Glory::Editor
 			}
 
 			m_pChildren[actualIndex]->Change(lastDir.string(), directory);
+			m_pChildren[actualIndex]->Refresh();
+			m_pChildren[actualIndex]->SortChildren();
 		}
 
 		std::vector<ContentBrowserItem*>::iterator it = m_pChildren.begin() + index;


### PR DESCRIPTION
Children will now also refresh during a refresh on content browser items
closes #16 