### PR TITLE
19 parenting fix

### DIFF
--- a/GloryEngine/EntityScenesEditorExtension/TransformEditor.cpp
+++ b/GloryEngine/EntityScenesEditorExtension/TransformEditor.cpp
@@ -26,8 +26,14 @@ namespace Glory::Editor
 		//glm::mat4 rotation = glm::eulerAngleXYX(90.0f, 90.0f, 0.0f);
 		glm::mat4 translation = glm::translate(glm::identity<glm::mat4>(), transform.Position);
 		m_Transform = translation * rotation * scale;
+
+		if (transform.Parent.IsValid())
+		{
+			Transform& parentTransform = transform.Parent.GetComponent<Transform>();
+			m_Transform = parentTransform.MatTransform * m_Transform;
+		}
 		m_LastTransform = m_Transform;
-		m_pGizmo = Gizmos::GetGizmo<DefaultGizmo>(m_pTarget->GetUUID(), m_Transform);
+		m_pGizmo = Gizmos::GetGizmo<DefaultGizmo>(m_pTarget->GetUUID(), transform.MatTransform);
 
 		m_pGizmo->OnManualManipulate = [&](const glm::mat4& newTransform)
 		{
@@ -66,14 +72,27 @@ namespace Glory::Editor
 			//glm::mat4 rotation = glm::eulerAngleXYX(90.0f, 90.0f, 0.0f);
 			glm::mat4 translation = glm::translate(glm::identity<glm::mat4>(), transform.Position);
 			m_Transform = translation * rotation * scale;
+
+			if (transform.Parent.IsValid())
+			{
+				Transform& parentTransform = transform.Parent.GetComponent<Transform>();
+				m_Transform = parentTransform.MatTransform * m_Transform;
+			}
 			m_LastTransform = m_Transform;
 			return;
 		}
 
-		glm::vec3 right(m_Transform[0][0], m_Transform[0][1], m_Transform[0][2]);
-		glm::vec3 up(m_Transform[1][0], m_Transform[1][1], m_Transform[1][2]);
-		glm::vec3 forward(m_Transform[2][0], m_Transform[2][1], m_Transform[2][2]);
-		glm::vec3 position(m_Transform[3][0], m_Transform[3][1], m_Transform[3][2]);
+		glm::mat4 localTransform = m_Transform;
+
+		if (transform.Parent.IsValid())
+		{
+			Transform& parentTransform = transform.Parent.GetComponent<Transform>();
+			localTransform = glm::inverse(parentTransform.MatTransform) * localTransform;
+		}
+		glm::vec3 right(localTransform[0][0], localTransform[0][1], localTransform[0][2]);
+		glm::vec3 up(localTransform[1][0], localTransform[1][1], localTransform[1][2]);
+		glm::vec3 forward(localTransform[2][0], localTransform[2][1], localTransform[2][2]);
+		glm::vec3 position(localTransform[3][0], localTransform[3][1], localTransform[3][2]);
 
 		glm::vec3 scale;
 		scale.x = glm::length(right);

--- a/GloryEngine/GloryCore/GScene.h
+++ b/GloryEngine/GloryCore/GScene.h
@@ -26,7 +26,7 @@ namespace Glory
 
         virtual SceneObject* CreateObject(const std::string& name) { return nullptr; };
         virtual SceneObject* CreateObject(const std::string& name, UUID uuid) { return nullptr; };
-        virtual void OnDeleteObject(SceneObject* pObject) { };
+        virtual void OnDeleteObject(SceneObject* pObject) {};
 
         virtual void OnObjectAdded(SceneObject* pObject) {};
 

--- a/GloryEngine/GloryCore/GScene.h
+++ b/GloryEngine/GloryCore/GScene.h
@@ -5,6 +5,14 @@
 
 namespace Glory
 {
+    struct DelayedParentData
+    {
+        DelayedParentData(SceneObject* pObjectToParent, UUID parentID) : ObjectToParent(pObjectToParent), ParentID(parentID) {}
+
+        SceneObject* ObjectToParent;
+        UUID ParentID;
+    };
+
     class GScene : public Resource
     {
     public:
@@ -19,6 +27,11 @@ namespace Glory
         SceneObject* GetSceneObject(size_t index);
         void DeleteObject(SceneObject* pObject);
 
+        SceneObject* FindSceneObject(UUID uuid) const;
+        void DelayedSetParent(SceneObject* pObjectToParent, UUID parentID);
+
+        void HandleDelayedParents();
+
     protected:
         virtual void Initialize() {};
         virtual void OnTick() {};
@@ -30,6 +43,8 @@ namespace Glory
 
         virtual void OnObjectAdded(SceneObject* pObject) {};
 
+        virtual void OnDelayedSetParent(const DelayedParentData& data);
+
     private:
         void SetUUID(UUID uuid);
 
@@ -37,5 +52,6 @@ namespace Glory
         friend class ScenesModule;
         friend class SceneObject;
         std::vector<SceneObject*> m_pSceneObjects;
+        std::vector<DelayedParentData> m_DelayedParents;
     };
 }

--- a/GloryEngine/GloryCore/SceneObject.cpp
+++ b/GloryEngine/GloryCore/SceneObject.cpp
@@ -20,11 +20,6 @@ namespace Glory
 
 	SceneObject::~SceneObject()
 	{
-		for (size_t i = 0; i < m_pChildren.size(); i++)
-		{
-			m_pScene->DeleteObject(m_pChildren[i]);
-		}
-		m_pChildren.clear();
 	}
 
 	size_t SceneObject::ChildCount()
@@ -120,6 +115,15 @@ namespace Glory
 	GScene* SceneObject::GetScene() const
 	{
 		return m_pScene;
+	}
+
+	void SceneObject::DestroyOwnChildren()
+	{
+		for (size_t i = 0; i < m_pChildren.size(); i++)
+		{
+			m_pScene->DeleteObject(m_pChildren[i]);
+		}
+		m_pChildren.clear();
 	}
 
 	const std::string& SceneObject::Name()

--- a/GloryEngine/GloryCore/SceneObject.cpp
+++ b/GloryEngine/GloryCore/SceneObject.cpp
@@ -20,6 +20,11 @@ namespace Glory
 
 	SceneObject::~SceneObject()
 	{
+		for (size_t i = 0; i < m_pChildren.size(); i++)
+		{
+			m_pScene->DeleteObject(m_pChildren[i]);
+		}
+		m_pChildren.clear();
 	}
 
 	size_t SceneObject::ChildCount()

--- a/GloryEngine/GloryCore/SceneObject.h
+++ b/GloryEngine/GloryCore/SceneObject.h
@@ -26,6 +26,7 @@ namespace Glory
         void SetScene(GScene* pScene);
         GScene* GetScene() const;
 
+
     public:
         const std::string& Name();
         void SetName(const std::string& name);
@@ -34,6 +35,7 @@ namespace Glory
     protected:
         virtual void Initialize() = 0;
         virtual void OnSetParent(SceneObject* pParent) = 0;
+        void DestroyOwnChildren();
 
     private:
         friend class GScene;

--- a/GloryEngine/GloryEditor/DeleteSceneObjectAction.h
+++ b/GloryEngine/GloryEditor/DeleteSceneObjectAction.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Undo.h"
 #include <SceneObject.h>
+#include <Serializer.h>
 
 namespace Glory::Editor
 {
@@ -13,6 +14,8 @@ namespace Glory::Editor
 	private:
 		virtual void OnUndo(const ActionRecord& actionRecord);
 		virtual void OnRedo(const ActionRecord& actionRecord);
+
+		void SerializeRecursive(SceneObject* pDeletedObject, YAML::Emitter& out);
 
 	private:
 		std::string m_SerializedObject;

--- a/GloryEngine/GloryEditor/Gizmos.h
+++ b/GloryEngine/GloryEditor/Gizmos.h
@@ -18,9 +18,6 @@ namespace Glory::Editor
 	class Gizmos
 	{
 	public:
-		GLORY_EDITOR_API Gizmos();
-		virtual GLORY_EDITOR_API ~Gizmos();
-
 		//static GLORY_EDITOR_API bool DrawGizmo(glm::mat4* transfrom);
 		template<class T, typename ...Args>
 		static T* GetGizmo(UUID uuid, Args&&... args)
@@ -39,6 +36,9 @@ namespace Glory::Editor
 		static ImGuizmo::MODE m_DefaultMode;
 
 	private:
+		GLORY_EDITOR_API Gizmos();
+		virtual GLORY_EDITOR_API ~Gizmos();
+
 		static void DrawGizmos(const glm::mat4& cameraView, const glm::mat4& cameraProjection);
 		static void Clear();
 
@@ -47,6 +47,7 @@ namespace Glory::Editor
 	private:
 		friend class MainEditor;
 		friend class SceneWindow;
+		friend class GloryContext;
 		static std::map<UUID, IGizmo*> m_pGizmos;
 		//static std::vector<bool> m_ManipulatedGizmos;
 	};

--- a/GloryEngine/GloryEntityScenes/Components.cpp
+++ b/GloryEngine/GloryEntityScenes/Components.cpp
@@ -5,17 +5,14 @@ namespace Glory
 {
 	Transform::Transform()
 		: Position(glm::vec3()), Rotation(glm::vec3()), Scale(glm::vec3(1.0f, 1.0f, 1.0f)),
-		MatTransform(glm::identity<glm::mat4>()), Parent(nullptr)
+		MatTransform(glm::identity<glm::mat4>()), Parent(Entity())
 	{
-
 	}
 
 	Transform::Transform(const glm::vec3& position, const glm::vec3& rotation, const glm::vec3& scale)
 		: Position(position), Rotation(rotation), Scale(scale),
-		Parent(nullptr)
+		MatTransform(glm::translate(glm::identity<glm::mat4>(), position) * glm::inverse(glm::mat4_cast(glm::quat(rotation))) * glm::scale(glm::identity<glm::mat4>(), scale)),
+		Parent(Entity())
 	{
-		//MatTransform = glm::scale(glm::identity<glm::mat4>(), scale);
-		//MatTransform = glm::rotate(MatTransform, rotation);
-		//MatTransform = glm::translate(MatTransform, position);
 	}
 }

--- a/GloryEngine/GloryEntityScenes/Components.h
+++ b/GloryEngine/GloryEntityScenes/Components.h
@@ -11,6 +11,7 @@
 #include <CameraRef.h>
 #include <Layer.h>
 #include <LightData.h>
+#include "Entity.h"
 
 namespace Glory
 {
@@ -25,7 +26,7 @@ namespace Glory
 
 		glm::mat4 MatTransform;
 
-		Transform* Parent;
+		Entity Parent;
 	};
 
 	struct MeshFilter

--- a/GloryEngine/GloryEntityScenes/Entity.cpp
+++ b/GloryEngine/GloryEntityScenes/Entity.cpp
@@ -17,6 +17,7 @@ namespace Glory
 
 	bool Entity::IsValid()
 	{
+		if (!m_pEntityScene) return false;
 		return m_pEntityScene->m_Registry.IsValid(m_EntityID);
 	}
 

--- a/GloryEngine/GloryEntityScenes/EntitySceneObject.cpp
+++ b/GloryEngine/GloryEntityScenes/EntitySceneObject.cpp
@@ -21,6 +21,7 @@ namespace Glory
 
 	EntitySceneObject::~EntitySceneObject()
 	{
+		SetParent(nullptr);
 		m_Entity.Destroy();
 	}
 
@@ -41,7 +42,7 @@ namespace Glory
 
 		if (pParent == nullptr)
 		{
-			transform.Parent = nullptr;
+			transform.Parent = Entity();
 			m_pParent = nullptr;
 			return;
 		}
@@ -55,9 +56,7 @@ namespace Glory
 		}
 
 		m_pParent = pEntityParent;
-
-		Transform& parentTransform = parentHandle.GetComponent<Transform>();
-		transform.Parent = &parentTransform;
+		transform.Parent = parentHandle;
 	}
 
 	Entity EntitySceneObject::GetEntityHandle()

--- a/GloryEngine/GloryEntityScenes/EntitySceneObject.cpp
+++ b/GloryEngine/GloryEntityScenes/EntitySceneObject.cpp
@@ -21,7 +21,6 @@ namespace Glory
 
 	EntitySceneObject::~EntitySceneObject()
 	{
-		SetParent(nullptr);
 		m_Entity.Destroy();
 	}
 

--- a/GloryEngine/GloryEntityScenes/EntitySceneSerializer.cpp
+++ b/GloryEngine/GloryEntityScenes/EntitySceneSerializer.cpp
@@ -37,6 +37,7 @@ namespace Glory
 			YAML::Node nextObject = node[i];
 			Serializer::DeserializeObject(pScene, nextObject);
 		}
+		pScene->HandleDelayedParents();
 
 		return pScene;
 	}

--- a/GloryEngine/GloryEntityScenes/TransformSystem.cpp
+++ b/GloryEngine/GloryEntityScenes/TransformSystem.cpp
@@ -23,7 +23,7 @@ namespace Glory
         }
 
         glm::mat4 scale = glm::scale(glm::identity<glm::mat4>(), pComponent.Scale);
-        glm::mat4 rotation = glm::mat4_cast(pComponent.Rotation);
+        glm::mat4 rotation = glm::inverse(glm::mat4_cast(pComponent.Rotation));
         //glm::mat4 rotation = glm::eulerAngleXYX(90.0f, 90.0f, 0.0f);
         glm::mat4 translation = glm::translate(glm::identity<glm::mat4>(), pComponent.Position);
         pComponent.MatTransform = startTransform * translation * rotation * scale;

--- a/GloryEngine/GloryEntityScenes/TransformSystem.cpp
+++ b/GloryEngine/GloryEntityScenes/TransformSystem.cpp
@@ -17,14 +17,14 @@ namespace Glory
     void Glory::TransformSystem::OnUpdate(Registry* pRegistry, EntityID entity, Transform& pComponent)
     {
         glm::mat4 startTransform = glm::identity<glm::mat4>();
-        if (pComponent.Parent != nullptr)
+        if (pComponent.Parent.IsValid())
         {
-            startTransform = pComponent.Parent->MatTransform;
+            Transform& parentTransform = pComponent.Parent.GetComponent<Transform>();
+            startTransform = parentTransform.MatTransform;
         }
 
         glm::mat4 scale = glm::scale(glm::identity<glm::mat4>(), pComponent.Scale);
         glm::mat4 rotation = glm::inverse(glm::mat4_cast(pComponent.Rotation));
-        //glm::mat4 rotation = glm::eulerAngleXYX(90.0f, 90.0f, 0.0f);
         glm::mat4 translation = glm::translate(glm::identity<glm::mat4>(), pComponent.Position);
         pComponent.MatTransform = startTransform * translation * rotation * scale;
     }


### PR DESCRIPTION
Fixed inverted rotation
Inverted matrix acquired from rotation quaternion of object transform

Parenting: Gizmos and crash fixes
- Fixed gizmos being in local position instead of world position when object is a child of another object
- Parents are now referenced by their entity ID instead of a pointer to its transform, this prevents weird behaviour due to dangling pointers when creating a new entity
- Fixed crash when deleting an object that has a parent or that has children

Parent serialization
- Parent is now serialized
- Fixed crash when unloading a scene
- Fixed undo object delete not recovering children of deleted object

closes #19 