### PR TITLE
Fix noderef incorrectly referencing yaml nodes (#170)

### DIFF
--- a/GloryEngine/Editor/GloryEditor/InputSettings.cpp
+++ b/GloryEngine/Editor/GloryEditor/InputSettings.cpp
@@ -61,7 +61,6 @@ namespace Glory::Editor
 					YAML::Node oldValue = YAML::Node(YAML::NodeType::Null);
 					YAML::Node newValue = YAML::Node(YAML::NodeType::Scalar);
 					newValue = "";
-					deviceTypesNode.PushBack<std::string>("");
 					NodeValueRef deviceTypeNode = deviceTypesNode[count];
 					Undo::YAMLEdit(file, deviceTypeNode.Path(), oldValue, newValue);
 					Undo::StopRecord();
@@ -92,7 +91,6 @@ namespace Glory::Editor
 			YAML::Node newValue{ YAML::NodeType::Map };
 			newValue["Name"] = "New Input Mode";
 			newValue["DeviceTypes"] = YAML::Node(YAML::NodeType::Sequence);
-			inputModes.PushBack(newValue);
 			NodeValueRef inputMode = inputModes[count];
 			Undo::YAMLEdit(file, inputMode.Path(), oldValue, newValue);
 			Undo::StopRecord();
@@ -451,7 +449,6 @@ namespace Glory::Editor
 							YAML::Node oldValue = YAML::Node(YAML::NodeType::Null);
 							NodeValueRef bindingNode = bindingsNode[count];
 							Undo::YAMLEdit(file, bindingNode.Path(), oldValue, newNode);
-							bindingsNode.PushBack(newNode);
 							Undo::StopRecord();
 							change = true;
 						};
@@ -484,7 +481,6 @@ namespace Glory::Editor
 					YAML::Node oldValue = YAML::Node(YAML::NodeType::Null);
 					NodeValueRef actionNode = actionsNode[count];
 					Undo::YAMLEdit(file, actionNode.Path(), oldValue, newNode);
-					actionsNode.PushBack(newNode);
 					Undo::StopRecord();
 					change = true;
 				};
@@ -515,7 +511,6 @@ namespace Glory::Editor
 			YAML::Node oldValue = YAML::Node(YAML::NodeType::Null);
 			NodeValueRef inputMap = inputMaps[count];
 			Undo::YAMLEdit(file, inputMap.Path(), oldValue, newNode);
-			inputMaps.PushBack(newNode);
 			Undo::StopRecord();
 
 			change = true;

--- a/GloryEngine/Engine/GloryCore/NodeRef.cpp
+++ b/GloryEngine/Engine/GloryCore/NodeRef.cpp
@@ -109,7 +109,7 @@ namespace Glory
 		return NodeValueRef(m_RootNode, m_Path.parent_path());
 	}
 
-	YAML::Node NodeValueRef::FindNode(YAML::Node node, std::filesystem::path path)
+	YAML::Node NodeValueRef::FindNode(YAML::Node& node, std::filesystem::path path)
 	{
 		if (path.empty() || path == ".") return node;
 
@@ -118,11 +118,11 @@ namespace Glory
 		{
 			const size_t index = std::stoul(subPathString.substr(2));
 			path = path.lexically_relative(subPathString);
-			YAML::Node nextNode = node[index];
+			YAML::Node& nextNode = node[index];
 			return FindNode(nextNode, path);
 		}
 
-		YAML::Node nextNode = node[subPathString];
+		YAML::Node& nextNode = node[subPathString];
 		path = path.lexically_relative(subPathString);
 		return FindNode(nextNode, path);
 	}

--- a/GloryEngine/Engine/GloryCore/NodeRef.h
+++ b/GloryEngine/Engine/GloryCore/NodeRef.h
@@ -64,7 +64,7 @@ namespace Glory
 		NodeValueRef Parent();
 
 	private:
-		YAML::Node FindNode(YAML::Node node, std::filesystem::path path);
+		YAML::Node FindNode(YAML::Node& node, std::filesystem::path path);
 
 	private:
 		YAML::Node& m_RootNode;


### PR DESCRIPTION
Caused a crash when opening the physics tab in project settings.