### PR TITLE
Preserve component execution order

### DIFF
--- a/GloryEngine/Engine/Modules/GloryEntityScenes/EntityScene.cpp
+++ b/GloryEngine/Engine/Modules/GloryEntityScenes/EntityScene.cpp
@@ -74,14 +74,6 @@ namespace Glory
 		// Spin
 		m_Registry.RegisterInvokaction<Spin>(GloryECS::InvocationType::Update, SpinSystem::OnUpdate);
 
-		// Scripted
-		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::OnAdd, ScriptedSystem::OnAdd);
-		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::Update, ScriptedSystem::OnUpdate);
-		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::Draw, ScriptedSystem::OnDraw);
-		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::Start, ScriptedSystem::OnStart);
-		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::Stop, ScriptedSystem::OnStop);
-		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::OnValidate, ScriptedSystem::OnValidate);
-
 		/* Physics Bodies */
 		m_Registry.RegisterInvokaction<PhysicsBody>(GloryECS::InvocationType::Start, PhysicsSystem::OnStart);
 		m_Registry.RegisterInvokaction<PhysicsBody>(GloryECS::InvocationType::Stop, PhysicsSystem::OnStop);
@@ -95,6 +87,14 @@ namespace Glory
 		m_Registry.RegisterInvokaction<CharacterController>(GloryECS::InvocationType::OnRemove, CharacterControllerSystem::OnStop);
 		m_Registry.RegisterInvokaction<CharacterController>(GloryECS::InvocationType::OnValidate, CharacterControllerSystem::OnValidate);
 		m_Registry.RegisterInvokaction<CharacterController>(GloryECS::InvocationType::Update, CharacterControllerSystem::OnUpdate);
+
+		// Scripted
+		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::OnAdd, ScriptedSystem::OnAdd);
+		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::Update, ScriptedSystem::OnUpdate);
+		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::Draw, ScriptedSystem::OnDraw);
+		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::Start, ScriptedSystem::OnStart);
+		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::Stop, ScriptedSystem::OnStop);
+		m_Registry.RegisterInvokaction<ScriptedComponent>(GloryECS::InvocationType::OnValidate, ScriptedSystem::OnValidate);
 	}
 
 	void EntityScene::OnTick()

--- a/GloryEngine/Engine/Modules/GloryEntityScenes/EntitySceneScenesModule.cpp
+++ b/GloryEngine/Engine/Modules/GloryEntityScenes/EntitySceneScenesModule.cpp
@@ -67,9 +67,11 @@ namespace Glory
 		RegisterComponent<MeshRenderer>();
 		RegisterComponent<ModelRenderer>();
 		RegisterComponent<LightComponent>();
-		RegisterComponent<ScriptedComponent>();
 		RegisterComponent<PhysicsBody>();
 		RegisterComponent<CharacterController>();
+
+		/* Always register scripted component as last to preserve execution order */
+		RegisterComponent<ScriptedComponent>();
 
 		const GloryReflect::FieldData* pColorField = LightComponent::GetTypeData()->GetFieldData(0);
 		GloryReflect::Reflect::SetFieldFlags(pColorField, Vec4Flags::Color);


### PR DESCRIPTION
Scripted components had their executions before other components when they should have their execution after all other components have executed