### PR TITLE
Build mono dependency and fix scripting crash

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 [submodule "GloryEngine/submodules/efsw"]
 	path = GloryEngine/submodules/efsw
 	url = https://github.com/SpartanJ/efsw
+[submodule "GloryEngine/submodules/mono"]
+	path = GloryEngine/submodules/mono
+	url = https://github.com/mono/mono.git

--- a/GloryEngine/Editor/Extensions/MonoEditorExtension/MonoEditorExtension.cpp
+++ b/GloryEngine/Editor/Extensions/MonoEditorExtension/MonoEditorExtension.cpp
@@ -196,7 +196,7 @@ namespace Glory::Editor
 		std::string name = pProject->Name() + ".dll";
 		std::filesystem::path path = pProject->ProjectPath();
 		path = path.parent_path().append("Library/Assembly");
-		/* TODO: Lib manager for uuser assemblies */
+		/* TODO: Lib manager for user assemblies */
 
 		m_pMonoScriptingModule->GetMonoManager()->AddLib(ScriptingLib("csharp", name, path.string(), true, nullptr, true));
 	}

--- a/GloryEngine/Editor/Extensions/MonoEditorExtension/premake5.lua
+++ b/GloryEngine/Editor/Extensions/MonoEditorExtension/premake5.lua
@@ -34,8 +34,6 @@ project "MonoEditorExtension"
 		"%{GloryIncludeDir.ImGui}",
 		"%{GloryIncludeDir.mono}",
 
-		"%{monoDir}/include/mono-2.0",
-
 		"%{IncludeDir.FA}",
 
 		"%{IncludeDir.ECS}",
@@ -105,28 +103,8 @@ project "MonoEditorExtension"
 		architecture "x86"
 		defines "WIN32"
 
-		libdirs
-		{
-			"%{monox86Dir}/lib",
-		}
-
-		includedirs
-		{
-			"%{monox86Dir}/include/mono-2.0",
-		}
-
 	filter "platforms:x64"
 		architecture "x64"
-
-		libdirs
-		{
-			"%{monoDir}/lib",
-		}
-
-		includedirs
-		{
-			"%{monoDir}/include/mono-2.0",
-		}
 
 	filter "configurations:Debug"
 		runtime "Debug"

--- a/GloryEngine/Modules/GloryEntityScenes/PhysicsSystem.cpp
+++ b/GloryEngine/Modules/GloryEntityScenes/PhysicsSystem.cpp
@@ -115,7 +115,7 @@ namespace Glory
 		};
 
 		EntityScene* pEntityScene = pRegistry->GetUserData<EntityScene*>();
-		pScript->InvokeSafe(pEntityScene->GetEntitySceneObjectFromEntityID(entity), "OnBodyActivated", args);
+		pScript->Invoke(pEntityScene->GetEntitySceneObjectFromEntityID(entity), "OnBodyActivated", args.data());
 	}
 
 	void PhysicsSystem::OnBodyDeactivated(uint32_t bodyID)
@@ -134,7 +134,7 @@ namespace Glory
 		};
 
 		EntityScene* pEntityScene = pRegistry->GetUserData<EntityScene*>();
-		pScript->InvokeSafe(pEntityScene->GetEntitySceneObjectFromEntityID(entity), "OnBodyDeactivated", args);
+		pScript->Invoke(pEntityScene->GetEntitySceneObjectFromEntityID(entity), "OnBodyDeactivated", args.data());
 	}
 
 	void PhysicsSystem::OnContactAdded(uint32_t body1ID, uint32_t body2ID)
@@ -160,7 +160,7 @@ namespace Glory
 			};
 
 			EntityScene* pEntityScene = pRegistry1->GetUserData<EntityScene*>();
-			pScript->InvokeSafe(pEntityScene->GetEntitySceneObjectFromEntityID(entity1), "OnContactAdded", args);
+			pScript->Invoke(pEntityScene->GetEntitySceneObjectFromEntityID(entity1), "OnContactAdded", args.data());
 		}
 
 		if (pRegistry2->HasComponent<ScriptedComponent>(entity2))
@@ -174,7 +174,7 @@ namespace Glory
 			};
 
 			EntityScene* pEntityScene = pRegistry2->GetUserData<EntityScene*>();
-			pScript->InvokeSafe(pEntityScene->GetEntitySceneObjectFromEntityID(entity2), "OnContactAdded", args);
+			pScript->Invoke(pEntityScene->GetEntitySceneObjectFromEntityID(entity2), "OnContactAdded", args.data());
 		}
 	}
 
@@ -201,7 +201,7 @@ namespace Glory
 			};
 
 			EntityScene* pEntityScene = pRegistry1->GetUserData<EntityScene*>();
-			pScript->InvokeSafe(pEntityScene->GetEntitySceneObjectFromEntityID(entity1), "OnContactPersisted", args);
+			pScript->Invoke(pEntityScene->GetEntitySceneObjectFromEntityID(entity1), "OnContactPersisted", args.data());
 		}
 
 		if (pRegistry2->HasComponent<ScriptedComponent>(entity2))
@@ -215,7 +215,7 @@ namespace Glory
 			};
 
 			EntityScene* pEntityScene = pRegistry2->GetUserData<EntityScene*>();
-			pScript->InvokeSafe(pEntityScene->GetEntitySceneObjectFromEntityID(entity2), "OnContactPersisted", args);
+			pScript->Invoke(pEntityScene->GetEntitySceneObjectFromEntityID(entity2), "OnContactPersisted", args.data());
 		}
 	}
 
@@ -242,7 +242,7 @@ namespace Glory
 			};
 
 			EntityScene* pEntityScene = pRegistry1->GetUserData<EntityScene*>();
-			pScript->InvokeSafe(pEntityScene->GetEntitySceneObjectFromEntityID(entity1), "OnContactRemoved", args);
+			pScript->Invoke(pEntityScene->GetEntitySceneObjectFromEntityID(entity1), "OnContactRemoved", args.data());
 		}
 
 		if (pRegistry2->HasComponent<ScriptedComponent>(entity2))
@@ -256,7 +256,7 @@ namespace Glory
 			};
 
 			EntityScene* pEntityScene = pRegistry2->GetUserData<EntityScene*>();
-			pScript->InvokeSafe(pEntityScene->GetEntitySceneObjectFromEntityID(entity2), "OnContactRemoved", args);
+			pScript->Invoke(pEntityScene->GetEntitySceneObjectFromEntityID(entity2), "OnContactRemoved", args.data());
 		}
 	}
 

--- a/GloryEngine/Modules/GloryEntityScenes/ScriptedSystem.cpp
+++ b/GloryEngine/Modules/GloryEntityScenes/ScriptedSystem.cpp
@@ -29,7 +29,7 @@ namespace Glory
 		pScript->LoadScriptProperties(pComponent.m_ScriptProperties, pComponent.m_ScriptData);
 		pScript->SetPropertyValues(pObject, pComponent.m_ScriptData);
 
-		pScript->InvokeSafe(pObject, "Start", std::vector<void*>{});
+		pScript->Invoke(pObject, "Start", nullptr);
 	}
 
 	void ScriptedSystem::OnStop(Glory::Utils::ECS::EntityRegistry* pRegistry, EntityID entity, ScriptedComponent& pComponent)
@@ -40,7 +40,7 @@ namespace Glory
 		if (pScript == nullptr) return;
 		ScenesModule* pEntityScenes = Game::GetGame().GetEngine()->GetMainModule<ScenesModule>();
 		SceneObject* pObject = pEntityScenes->GetSceneObjectFromObjectID(entity);
-		pScript->InvokeSafe(pObject, "Stop", std::vector<void*>{});
+		pScript->Invoke(pObject, "Stop", nullptr);
 	}
 
 	void ScriptedSystem::OnValidate(Glory::Utils::ECS::EntityRegistry* pRegistry, EntityID entity, ScriptedComponent& pComponent)
@@ -55,7 +55,7 @@ namespace Glory
 		ScenesModule* pEntityScenes = Game::GetGame().GetEngine()->GetMainModule<ScenesModule>();
 		SceneObject* pObject = pEntityScenes->GetSceneObjectFromObjectID(entity);
 		pScript->SetPropertyValues(pObject, pComponent.m_ScriptData);
-		pScript->InvokeSafe(pObject, "OnValidate", std::vector<void*>{});
+		pScript->Invoke(pObject, "OnValidate", nullptr);
 	}
 
 	void ScriptedSystem::OnUpdate(Glory::Utils::ECS::EntityRegistry* pRegistry, EntityID entity, ScriptedComponent& pComponent)
@@ -66,7 +66,7 @@ namespace Glory
 		if (pScript == nullptr) return;
 		ScenesModule* pEntityScenes = Game::GetGame().GetEngine()->GetMainModule<ScenesModule>();
 		SceneObject* pObject = pEntityScenes->GetSceneObjectFromObjectID(entity);
-		pScript->InvokeSafe(pObject, "Update", std::vector<void*>{});
+		pScript->Invoke(pObject, "Update", nullptr);
 		pScript->GetPropertyValues(pObject, pComponent.m_ScriptData);
 	}
 
@@ -78,6 +78,6 @@ namespace Glory
 		if (pScript == nullptr) return;
 		ScenesModule* pEntityScenes = Game::GetGame().GetEngine()->GetMainModule<ScenesModule>();
 		SceneObject* pObject = pEntityScenes->GetSceneObjectFromObjectID(entity);
-		pScript->InvokeSafe(pObject, "Draw", std::vector<void*>{});
+		pScript->Invoke(pObject, "Draw", nullptr);
 	}
 }

--- a/GloryEngine/Modules/GloryMonoScripting/AssemblyDomain.cpp
+++ b/GloryEngine/Modules/GloryMonoScripting/AssemblyDomain.cpp
@@ -2,6 +2,8 @@
 #include "Assembly.h"
 #include "MonoScriptObjectManager.h"
 
+#include <mono/metadata/exception.h>
+
 namespace Glory
 {
 	AssemblyDomain::AssemblyDomain(const std::string& name, MonoDomain* pDomain)
@@ -62,9 +64,16 @@ namespace Glory
 		return m_pScriptObjectManager;
 	}
 
-	MonoObject* AssemblyDomain::InvokeMethod(MonoMethod* pMethod, MonoObject* pObject, MonoObject** pExceptionObject, void** args)
+	MonoObject* AssemblyDomain::InvokeMethod(MonoMethod* pMethod, MonoObject* pObject, void** args)
 	{
-		return mono_runtime_invoke(pMethod, pObject, args, pExceptionObject);
+		MonoObject* pExceptionObject = nullptr;
+		MonoObject* result = mono_runtime_invoke(pMethod, pObject, args, &pExceptionObject);
+		if (pExceptionObject)
+		{
+			mono_print_unhandled_exception(pExceptionObject);
+			return nullptr;
+		}
+		return result;
 	}
 
 	size_t AssemblyDomain::AssemblyCount()

--- a/GloryEngine/Modules/GloryMonoScripting/AssemblyDomain.h
+++ b/GloryEngine/Modules/GloryMonoScripting/AssemblyDomain.h
@@ -29,7 +29,7 @@ namespace Glory
 		GLORY_API const std::string& GetMainAssemblyName();
 		GLORY_API MonoScriptObjectManager* ScriptObjectManager();
 
-		GLORY_API MonoObject* InvokeMethod(MonoMethod* pMethod, MonoObject* pObject, MonoObject** pExceptionObject, void** args);
+		GLORY_API MonoObject* InvokeMethod(MonoMethod* pMethod, MonoObject* pObject, void** args);
 
 		GLORY_API size_t AssemblyCount();
 		GLORY_API void ForEachAssembly(std::function<void(Assembly*)> callback);

--- a/GloryEngine/Modules/GloryMonoScripting/MonoScript.cpp
+++ b/GloryEngine/Modules/GloryMonoScripting/MonoScript.cpp
@@ -46,8 +46,7 @@ namespace Glory
 		std::string fullMethodName = ".::" + method;
 		MonoMethod* pMethod = pClass->GetMethod(fullMethodName);
 		if (pMethod == nullptr) return;
-		MonoObject* pException = nullptr;
-		pDomain->InvokeMethod(pMethod, pMonoObject, &pException, args);
+		pDomain->InvokeMethod(pMethod, pMonoObject, args);
 	}
 
 	void MonoScript::InvokeSafe(Object* pObject, const std::string& method, std::vector<void*>& args)

--- a/GloryEngine/Modules/GloryMonoScripting/ScriptingMethodsHelper.cpp
+++ b/GloryEngine/Modules/GloryMonoScripting/ScriptingMethodsHelper.cpp
@@ -8,6 +8,9 @@ namespace Glory
 {
 	void ScriptingMethodsHelper::InvokeScriptingMethod(MonoObject* pObject, const std::string& methodName, std::vector<void*>& args)
 	{
+		/* Unfortunately this is slow and proned to crashing, so will not be used anymore */
+		throw new std::exception("ScriptingMethodsHelper::InvokeScriptingMethod should not be called anymore");
+
 		const size_t argCount = args.size();
 
 		MonoString* pMonoString = mono_string_new(mono_domain_get(), methodName.c_str());

--- a/GloryEngine/Modules/GloryMonoScripting/premake5.lua
+++ b/GloryEngine/Modules/GloryMonoScripting/premake5.lua
@@ -85,6 +85,9 @@ project "GloryMonoScripting"
 		("{COPY} ./Module.yaml %{moduleOutDir}"),
 		("{COPY} ./Assets %{moduleOutDir}/Assets"),
 		("{COPY} ./Resources %{moduleOutDir}/Resources"),
+
+		("{COPY} \"%{monoDir}/lib/mono/4.5/*\" %{moduleOutDir}/Dependencies/mono/4.5/"),
+		("{COPY} %{DepsBinDir}/mono-2.0-sgen.dll %{moduleOutDir}/Dependencies/"),
 	}
 
 	filter "system:windows"
@@ -100,42 +103,8 @@ project "GloryMonoScripting"
 		architecture "x86"
 		defines "WIN32"
 
-		libdirs
-		{
-			"%{monox86Dir}/lib",
-		}
-
-		includedirs
-		{
-			"%{monox86Dir}/include/mono-2.0",
-		}
-
-		postbuildcommands
-		{
-			("{COPY} \"%{monox86Dir}/lib/mono/4.5/*\" %{moduleOutDir}/Dependencies/mono/4.5/"),
-			("{COPY} \"%{monox86Dir}/bin/mono-2.0-sgen.dll\" %{moduleOutDir}/Dependencies"),
-			--("{COPY} \"%{monox86Dir}/lib/mono/4.5/*\" ./mono/4.5/"),
-		}
-
 	filter "platforms:x64"
 		architecture "x64"
-
-		libdirs
-		{
-			"%{monoDir}/lib",
-		}
-
-		includedirs
-		{
-			"%{monoDir}/include/mono-2.0",
-		}
-
-		postbuildcommands
-		{
-			("{COPY} \"%{monoDir}/lib/mono/4.5/*\" %{moduleOutDir}/Dependencies/mono/4.5/"),
-			("{COPY} \"%{monoDir}/bin/mono-2.0-sgen.dll\" %{moduleOutDir}/Dependencies"),
-			--("{COPY} \"%{monoDir}/lib/mono/4.5/*\" ./mono/4.5/"),
-		}
 
 	filter "configurations:Debug"
 		runtime "Debug"

--- a/GloryEngine/Scripting/Mono/GloryEntitiesMonoExtender/premake5.lua
+++ b/GloryEngine/Scripting/Mono/GloryEntitiesMonoExtender/premake5.lua
@@ -80,28 +80,8 @@ project "GloryEntitiesMonoExtender"
 		architecture "x86"
 		defines "WIN32"
 
-		libdirs
-		{
-			"%{monox86Dir}/lib",
-		}
-
-		includedirs
-		{
-			"%{monox86Dir}/include/mono-2.0",
-		}
-
 	filter "platforms:x64"
 		architecture "x64"
-
-		libdirs
-		{
-			"%{monoDir}/lib",
-		}
-
-		includedirs
-		{
-			"%{monoDir}/include/mono-2.0",
-		}
 
 	filter "configurations:Debug"
 		runtime "Debug"

--- a/GloryEngine/install-dependencies.sh
+++ b/GloryEngine/install-dependencies.sh
@@ -159,7 +159,14 @@ cp "lib/${EFSW_LIB}.pdb" "../../Dependencies/${CONFIG}/lib/${EFSW_LIB}.pdb"
 mkdir "../../Dependencies/${CONFIG}/include/efsw"
 cp "include/efsw/efsw.h" "../../Dependencies/${CONFIG}/include/efsw/efsw.h"
 cp "include/efsw/efsw.hpp" "../../Dependencies/${CONFIG}/include/efsw/efsw.hpp"
+cd ..
 
+cd mono
+msbuild.exe msvc/mono.sln -p:Platform=x64 -p:Configuration=$CONFIG -p:MONO_TARGET_GC=sgen
+find "msvc/build/sgen/x64/lib/${CONFIG}" -name \*.* -exec cp {} "../../Dependencies/${CONFIG}/lib/" \;
+find "msvc/build/sgen/x64/bin/${CONFIG}" -name \*.* -exec cp {} "../../Dependencies/${CONFIG}/bin/" \;
+find "msvc/build/sgen/x64/bin/${CONFIG}" -name \*.* -exec cp {} "../../Dependencies/${CONFIG}/bin/" \;
+cp -r msvc/include/mono "../../Dependencies/${CONFIG}/include"
 
 # Jolt
 # Jolt now gets built in the jolt module itself because I could not solve an illusive linker error

--- a/GloryEngine/premake5.lua
+++ b/GloryEngine/premake5.lua
@@ -20,7 +20,6 @@ workspace "GloryEngine"
 
 vulkanDir								= "C:/VulkanSDK/1.2.182.0"
 monoDir									= "C:/Program Files/Mono"
-monox86Dir								= "C:/Program Files (x86)/Mono"
 leakDetectorDir							= "C:/Program Files (x86)/Visual Leak Detector/include"
 
 rootDir									= "%{wks.location}"


### PR DESCRIPTION
InvokeSafe will no longer be used since it is slow and prone to crashing. Exceptions are now caught on the C++ side and then printed using the log callback.

Probably fixes #242 but needs testing.