### PR TITLE
Refactor serialization

### DIFF
--- a/GloryEngine/Editor/GloryEditor/CreateEntityObjectsCallbacks.cpp
+++ b/GloryEngine/Editor/GloryEditor/CreateEntityObjectsCallbacks.cpp
@@ -15,7 +15,6 @@ namespace Glory::Editor
     {
 		if (!pObject)
 		{
-			Selection::SetActiveObject(nullptr);
 			GScene* pActiveScene = EditorApplication::GetInstance()->GetEngine()->GetSceneManager()->GetActiveScene();
 			if (pActiveScene == nullptr) pActiveScene = EditorApplication::GetInstance()->GetSceneManager().NewScene("Empty Scene", true);
 			Entity newEntity = pActiveScene->CreateEmptyObject(name, UUID());
@@ -27,7 +26,6 @@ namespace Glory::Editor
 		{
 		case ObjectMenuType::T_Scene:
 		{
-			Selection::SetActiveObject(nullptr);
 			GScene* pScene = (GScene*)pObject;
 			if (pScene == nullptr) return {};
 			Entity newEntity = pScene->CreateEmptyObject(name, UUID());
@@ -37,7 +35,6 @@ namespace Glory::Editor
 
 		case ObjectMenuType::T_SceneObject:
 		{
-			Selection::SetActiveObject(nullptr);
 			EditableEntity* pSceneObject = (EditableEntity*)pObject;
 			if (pSceneObject == nullptr) return {};
 			GScene* pScene = EditorApplication::GetInstance()->GetSceneManager().GetOpenScene(pSceneObject->SceneID());

--- a/GloryEngine/Editor/GloryEditor/CreateObjectAction.cpp
+++ b/GloryEngine/Editor/GloryEditor/CreateObjectAction.cpp
@@ -28,11 +28,9 @@ namespace Glory::Editor
 		if (!entity.IsValid()) return;
 
 		/* Take a snapshot of the object for redoing */
-		YAML::Emitter out;
-		out << YAML::BeginSeq;
-		EditorSceneSerializer::SerializeEntityRecursive(EditorApplication::GetInstance()->GetEngine(), pScene, entity.GetEntityID(), out);
-		out << YAML::EndSeq;
-		m_SerializedObject = out.c_str();
+		auto entities = m_SerializedObject.RootNodeRef().ValueRef();
+		entities.SetSequence();
+		EditorSceneSerializer::SerializeEntityRecursive(EditorApplication::GetInstance()->GetEngine(), pScene, entity.GetEntityID(), entities);
 
 		pScene->DestroyEntity(entity.GetEntityID());
 	}
@@ -41,12 +39,11 @@ namespace Glory::Editor
 	{
 		GScene* pScene = EditorApplication::GetInstance()->GetSceneManager().GetOpenScene(m_SceneID);
 		if (pScene == nullptr) return;
-		YAML::Node node = YAML::Load(m_SerializedObject.c_str());
-		Utils::NodeRef entities{node};
+		Utils::NodeRef entities = m_SerializedObject.RootNodeRef();
 		for (size_t i = 0; i < entities.ValueRef().Size(); i++)
 		{
 			Utils::NodeValueRef entity = entities.ValueRef()[i];
-			EditorSceneSerializer::DeserializeEntity(EditorApplication::GetInstance()->GetEngine(), pScene, entity.Node());
+			EditorSceneSerializer::DeserializeEntity(EditorApplication::GetInstance()->GetEngine(), pScene, entity);
 		}
 
 		Selection::SetActiveObject(GetEditableEntity(pScene->GetEntityByUUID(actionRecord.ObjectID).GetEntityID(), pScene));

--- a/GloryEngine/Editor/GloryEditor/CreateObjectAction.cpp
+++ b/GloryEngine/Editor/GloryEditor/CreateObjectAction.cpp
@@ -20,8 +20,6 @@ namespace Glory::Editor
 
 	void CreateObjectAction::OnUndo(const ActionRecord& actionRecord)
 	{
-		Selection::SetActiveObject(nullptr);
-
 		GScene* pScene = EditorApplication::GetInstance()->GetSceneManager().GetOpenScene(m_SceneID);
 
 		Entity entity = pScene->GetEntityByUUID(actionRecord.ObjectID);
@@ -32,7 +30,7 @@ namespace Glory::Editor
 		entities.SetSequence();
 		EditorSceneSerializer::SerializeEntityRecursive(EditorApplication::GetInstance()->GetEngine(), pScene, entity.GetEntityID(), entities);
 
-		pScene->DestroyEntity(entity.GetEntityID());
+		DestroyEntity(entity.GetEntityID(), pScene);
 	}
 
 	void CreateObjectAction::OnRedo(const ActionRecord& actionRecord)

--- a/GloryEngine/Editor/GloryEditor/CreateObjectAction.h
+++ b/GloryEngine/Editor/GloryEditor/CreateObjectAction.h
@@ -3,7 +3,7 @@
 #include "GloryEditor.h"
 
 #include "EntityID.h"
-#include <yaml-cpp/yaml.h>
+#include <NodeRef.h>
 
 namespace Glory
 {
@@ -21,7 +21,7 @@ namespace Editor
         virtual void OnRedo(const ActionRecord& actionRecord);
 
     private:
-        std::string m_SerializedObject;
+        Utils::InMemoryYAML m_SerializedObject;
         UUID m_SceneID;
     };
 }

--- a/GloryEngine/Editor/GloryEditor/DeleteSceneObjectAction.h
+++ b/GloryEngine/Editor/GloryEditor/DeleteSceneObjectAction.h
@@ -19,7 +19,7 @@ namespace Editor
 		virtual void OnRedo(const ActionRecord& actionRecord);
 
 	private:
-		std::string m_SerializedObject;
+		Utils::InMemoryYAML m_SerializedObject;
 		UUID m_OriginalSceneUUID;
 		bool m_WasSelected;
 	};

--- a/GloryEngine/Editor/GloryEditor/EditorMaterialManager.cpp
+++ b/GloryEngine/Editor/GloryEditor/EditorMaterialManager.cpp
@@ -244,7 +244,7 @@ namespace Glory::Editor
 				size_t index = 0;
 				pMaterial->GetPropertyInfoIndex(*this, displayName, index);
 				const size_t offset = pMaterial->GetPropertyInfoAt(*this, index)->Offset();
-				m_pEngine->GetSerializers().DeserializeProperty(pMaterial->GetBufferReference(*this), type, offset, typeData != nullptr ? typeData->m_Size : 4, value.Node());
+				m_pEngine->GetSerializers().DeserializeProperty(pMaterial->GetBufferReference(*this), type, offset, typeData != nullptr ? typeData->m_Size : 4, value);
 			}
 			else
 			{
@@ -277,7 +277,7 @@ namespace Glory::Editor
 
 			MaterialPropertyInfo* propertyInfo = pMaterialData->GetPropertyInfoAt(manager, propertyIndex);
 
-			YAML::Node value = prop["Value"].Node();
+			auto value = prop["Value"];
 
 			if (!propertyInfo->IsResource())
 			{
@@ -288,8 +288,8 @@ namespace Glory::Editor
 			}
 			else
 			{
-				if (!value.IsDefined() || !value.IsScalar()) continue;
-				const UUID id = value.as<uint64_t>();
+				if (!value.Exists() || !value.IsScalar()) continue;
+				const UUID id = value.As<uint64_t>();
 				size_t resourceIndex = propertyInfo->Offset();
 				if (pMaterialData->ResourceCount() > resourceIndex) *pMaterialData->GetResourceUUIDPointer(manager, resourceIndex) = id;
 			}

--- a/GloryEngine/Editor/GloryEditor/EditorPlayer.cpp
+++ b/GloryEngine/Editor/GloryEditor/EditorPlayer.cpp
@@ -52,10 +52,7 @@ namespace Glory::Editor
 		if (pSelected != nullptr) m_SelectedObjectBeforeStart = pSelected->GetUUID();
 		Selection::Clear();
 		m_UndoHistoryIndex = Undo::GetHistorySize();
-		YAML::Emitter out;
-
-		EditorApplication::GetInstance()->GetSceneManager().SerializeOpenScenes(out);
-		m_SerializedScenes = out.c_str();
+		EditorApplication::GetInstance()->GetSceneManager().SerializeOpenScenes(m_SerializedScenes);
 
 		//if (pSelected) Selection::SetActiveObject(pSelected);
 
@@ -111,8 +108,7 @@ namespace Glory::Editor
 
 		Selection::Clear();
 		EditorApplication::GetInstance()->GetSceneManager().CloseAllScenes();
-		YAML::Node node = YAML::Load(m_SerializedScenes);
-		EditorApplication::GetInstance()->GetSceneManager().OpenAllFromNode(node);
+		EditorApplication::GetInstance()->GetSceneManager().OpenAllFromYAML(m_SerializedScenes);
 
 		//pSelected = Object::FindObject(toSelect);
 		//Selection::SetActiveObject(pSelected);

--- a/GloryEngine/Editor/GloryEditor/EditorPlayer.h
+++ b/GloryEngine/Editor/GloryEditor/EditorPlayer.h
@@ -6,6 +6,7 @@
 #include <IModuleLoopHandler.h>
 #include <GScene.h>
 #include <vector>
+#include <NodeRef.h>
 
 namespace Glory::Editor
 {
@@ -38,7 +39,7 @@ namespace Glory::Editor
 		EditorPlayer();
 		virtual ~EditorPlayer();
 
-		std::string m_SerializedScenes;
+		Utils::InMemoryYAML m_SerializedScenes;
 		size_t m_UndoHistoryIndex;
 		UUID m_SelectedObjectBeforeStart;
 		bool m_IsPaused;

--- a/GloryEngine/Editor/GloryEditor/EditorSceneManager.h
+++ b/GloryEngine/Editor/GloryEditor/EditorSceneManager.h
@@ -39,8 +39,8 @@ namespace Glory::Editor
 		GLORY_EDITOR_API void SaveScene(UUID uuid);
 		GLORY_EDITOR_API void SaveSceneAs(UUID uuid);
 
-		GLORY_EDITOR_API void SerializeOpenScenes(YAML::Emitter& out);
-		GLORY_EDITOR_API void OpenAllFromNode(YAML::Node& node);
+		GLORY_EDITOR_API void SerializeOpenScenes(Utils::InMemoryYAML out);
+		GLORY_EDITOR_API void OpenAllFromYAML(Utils::InMemoryYAML data);
 
 		GLORY_EDITOR_API void SetActiveScene(GScene* pScene);
 		GLORY_EDITOR_API void SetSceneDirty(GScene* pScene, bool dirty = true);
@@ -49,7 +49,7 @@ namespace Glory::Editor
 		GLORY_EDITOR_API bool HasUnsavedChanges();
 
 		GLORY_EDITOR_API void DuplicateSceneObject(Entity entity);
-		GLORY_EDITOR_API void PasteSceneObject(GScene* pScene, Utils::ECS::EntityID parent, YAML::Node& node);
+		GLORY_EDITOR_API void PasteSceneObject(GScene* pScene, Utils::ECS::EntityID parent, Utils::NodeValueRef entities);
 
 		GLORY_EDITOR_API YAMLResource<GScene>* GetSceneFile(UUID uuid);
 

--- a/GloryEngine/Editor/GloryEditor/EditorSceneSerializer.cpp
+++ b/GloryEngine/Editor/GloryEditor/EditorSceneSerializer.cpp
@@ -91,7 +91,7 @@ namespace Glory::Editor
 			void* pTransformAddress = pRegistry.GetComponentAddress(entity, pEntityView->ComponentUUIDAt(0));
 			auto transform = entityNode["Transform"];
 			transform.Set(YAML::Node(YAML::NodeType::Map));
-			pEngine->GetSerializers().SerializeProperty("Properties", pTransformTypeData, pTransformAddress, transform);
+			pEngine->GetSerializers().SerializeProperty(pTransformTypeData, pTransformAddress, transform["Properties"]);
 		
 			/* TODO: Serialize overrides */
 			return;
@@ -222,7 +222,7 @@ namespace Glory::Editor
 		node["TypeHash"].Set(uint64_t(type));
 		node["Active"].Set(pRegistry->GetTypeView(type)->IsActive(entity));
 
-		pEngine->GetSerializers().SerializeProperty("Properties", pType, pRegistry->GetComponentAddress(entity, compUUID), node);
+		pEngine->GetSerializers().SerializeProperty(pType, pRegistry->GetComponentAddress(entity, compUUID), node["Properties"]);
 	}
 
 	void EditorSceneSerializer::DeserializeComponent(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, UUIDRemapper& uuidRemapper, Utils::NodeValueRef component, Flags flags)

--- a/GloryEngine/Editor/GloryEditor/EditorSceneSerializer.h
+++ b/GloryEngine/Editor/GloryEditor/EditorSceneSerializer.h
@@ -2,6 +2,8 @@
 #include "Entity.h"
 #include "GloryEditor.h"
 
+#include <NodeRef.h>
+
 namespace YAML
 {
     class Node;
@@ -36,7 +38,7 @@ namespace Editor
          * @param pScene The scene to serialize
          * @param out The emitter to serialize to
          */
-        GLORY_EDITOR_API static void SerializeScene(Engine* pEngine, GScene* pScene, YAML::Emitter& out);
+        GLORY_EDITOR_API static void SerializeScene(Engine* pEngine, GScene* pScene, Utils::NodeRef node);
         /** @brief Deserialize a scene from a YAML node
          * @param pEngine The current engine instance
          * @param object The root yaml node of the serialized scene
@@ -44,7 +46,7 @@ namespace Editor
          * @param name Name to pass to the scenes constructor
          * @param flags Deserialization flags
          */
-        GLORY_EDITOR_API static GScene* DeserializeScene(Engine* pEngine, YAML::Node& object, UUID uuid, const std::string& name, Flags flags = Flags(0));
+        GLORY_EDITOR_API static GScene* DeserializeScene(Engine* pEngine, Utils::NodeRef node, UUID uuid, const std::string& name, Flags flags = Flags(0));
 
         /** @brief Deserialize a scene from a YAML node
          * @param pEngine The current engine instance
@@ -54,7 +56,7 @@ namespace Editor
          * @param name Name to pass to the scenes constructor
          * @param flags Deserialization flags
          */
-        GLORY_EDITOR_API static void DeserializeScene(Engine* pEngine, GScene* pScene, YAML::Node& object, UUID uuid, const std::string& name, Flags flags = Flags(0));
+        GLORY_EDITOR_API static void DeserializeScene(Engine* pEngine, GScene* pScene, Utils::NodeRef node, UUID uuid, const std::string& name, Flags flags = Flags(0));
 
         /** @brief Serialize an entity
          * @param pEngine The current engine instance
@@ -62,21 +64,21 @@ namespace Editor
          * @param entity ID of the entity
          * @param out The emitter to serialize to
          */
-        GLORY_EDITOR_API static void SerializeEntity(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, YAML::Emitter& out);
+        GLORY_EDITOR_API static void SerializeEntity(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, Utils::NodeValueRef entityNode);
         /** @brief Serialize an entity and all its children
          * @param pEngine The current engine instance
          * @param pScene The scene in which the entity exists
          * @param entity ID of the entity
          * @param out The emitter to serialize to
          */
-        GLORY_EDITOR_API static void SerializeEntityRecursive(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, YAML::Emitter& out);
+        GLORY_EDITOR_API static void SerializeEntityRecursive(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, Utils::NodeValueRef entities);
         /** @brief Deserialize an entity from a YAML node
          * @param pEngine The current engine instance
          * @param pScene The scene to add the entity to
          * @param object The root node of the serialized entity
          * @param flags Deserialization flags
          */
-        GLORY_EDITOR_API static Entity DeserializeEntity(Engine* pEngine, GScene* pScene, YAML::Node& object, Flags flags = Flags(0));
+        GLORY_EDITOR_API static Entity DeserializeEntity(Engine* pEngine, GScene* pScene, Utils::NodeRef node, Flags flags = Flags(0));
         /** @brief Serialize a component on an entity
          * @param pEngine The current engine instance
          * @param pRegistry The registry in which the entity exists
@@ -85,7 +87,7 @@ namespace Editor
          * @param index Index of the component to serialize
          * @param out The emitter to serialize to
          */
-        GLORY_EDITOR_API static void SerializeComponent(Engine* pEngine, Utils::ECS::EntityRegistry* pRegistry, Utils::ECS::EntityView* pEntityView, Utils::ECS::EntityID entity, size_t index, YAML::Emitter& out);
+        GLORY_EDITOR_API static void SerializeComponent(Engine* pEngine, Utils::ECS::EntityRegistry* pRegistry, Utils::ECS::EntityView* pEntityView, Utils::ECS::EntityID entity, size_t index, Utils::NodeValueRef node);
         /** @brief Deserialize a component to an entity
          * @param pEngine The current engine instance
          * @param pScene The scene in which the entity exists on which to add the component
@@ -94,7 +96,7 @@ namespace Editor
          * @param object The root node of the serialized component
          * @param flags Deserialization flags
          */
-        GLORY_EDITOR_API static void DeserializeComponent(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, UUIDRemapper& uuidRemapper, YAML::Node& object, Flags flags = Flags(0));
+        GLORY_EDITOR_API static void DeserializeComponent(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, UUIDRemapper& uuidRemapper, Utils::NodeRef node, Flags flags = Flags(0));
     };
 }
 }

--- a/GloryEngine/Editor/GloryEditor/EditorSceneSerializer.h
+++ b/GloryEngine/Editor/GloryEditor/EditorSceneSerializer.h
@@ -33,70 +33,78 @@ namespace Editor
             NoComponentCallbacks = 4,
         };
 
-        /** @brief Serialize a scene to a YAML emitter
+        /**
+         * @brief Serialize a scene to a YAML emitter
          * @param pEngine The current engine instance
          * @param pScene The scene to serialize
-         * @param out The emitter to serialize to
+         * @param node YAML node to serialize the scene to
          */
-        GLORY_EDITOR_API static void SerializeScene(Engine* pEngine, GScene* pScene, Utils::NodeRef node);
-        /** @brief Deserialize a scene from a YAML node
+        GLORY_EDITOR_API static void SerializeScene(Engine* pEngine, GScene* pScene, Utils::NodeValueRef node);
+        /**
+         * @brief Deserialize a scene from a YAML node
          * @param pEngine The current engine instance
-         * @param object The root yaml node of the serialized scene
+         * @param node The root yaml node of the serialized scene
          * @param uuid UUID to pass to the scenes constructor
          * @param name Name to pass to the scenes constructor
          * @param flags Deserialization flags
          */
-        GLORY_EDITOR_API static GScene* DeserializeScene(Engine* pEngine, Utils::NodeRef node, UUID uuid, const std::string& name, Flags flags = Flags(0));
+        GLORY_EDITOR_API static GScene* DeserializeScene(Engine* pEngine, Utils::NodeValueRef node, UUID uuid, const std::string& name, Flags flags = Flags(0));
 
-        /** @brief Deserialize a scene from a YAML node
+        /**
+         * @brief Deserialize a scene from a YAML node
          * @param pEngine The current engine instance
          * @param pScene Scene instance to deserialize the data into
-         * @param object The root yaml node of the serialized scene
+         * @param node The root yaml node of the serialized scene
          * @param uuid UUID to pass to the scenes constructor
          * @param name Name to pass to the scenes constructor
          * @param flags Deserialization flags
          */
-        GLORY_EDITOR_API static void DeserializeScene(Engine* pEngine, GScene* pScene, Utils::NodeRef node, UUID uuid, const std::string& name, Flags flags = Flags(0));
+        GLORY_EDITOR_API static void DeserializeScene(Engine* pEngine, GScene* pScene, Utils::NodeValueRef node, UUID uuid, const std::string& name, Flags flags = Flags(0));
 
-        /** @brief Serialize an entity
+        /**
+         * @brief Serialize an entity
          * @param pEngine The current engine instance
          * @param pScene The scene in which the entity exists
          * @param entity ID of the entity
-         * @param out The emitter to serialize to
+         * @param entityNode YAML node to serialize the entity to
          */
         GLORY_EDITOR_API static void SerializeEntity(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, Utils::NodeValueRef entityNode);
-        /** @brief Serialize an entity and all its children
+        /**
+         * @brief Serialize an entity and all its children
          * @param pEngine The current engine instance
          * @param pScene The scene in which the entity exists
          * @param entity ID of the entity
-         * @param out The emitter to serialize to
+         * @param entities The YAML sequence node to serialize to
          */
         GLORY_EDITOR_API static void SerializeEntityRecursive(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, Utils::NodeValueRef entities);
-        /** @brief Deserialize an entity from a YAML node
+        /**
+         * @brief Deserialize an entity from a YAML node
          * @param pEngine The current engine instance
          * @param pScene The scene to add the entity to
-         * @param object The root node of the serialized entity
+         * @param node Serialized YAML entity data
          * @param flags Deserialization flags
          */
-        GLORY_EDITOR_API static Entity DeserializeEntity(Engine* pEngine, GScene* pScene, Utils::NodeRef node, Flags flags = Flags(0));
-        /** @brief Serialize a component on an entity
+        GLORY_EDITOR_API static Entity DeserializeEntity(Engine* pEngine, GScene* pScene, Utils::NodeValueRef node, Flags flags = Flags(0));
+        /**
+         * @brief Serialize a component on an entity
          * @param pEngine The current engine instance
          * @param pRegistry The registry in which the entity exists
          * @param pEntityView View of the entity
          * @param entity ID of the entity
          * @param index Index of the component to serialize
-         * @param out The emitter to serialize to
+         * @param node The YAML node to serialize to
          */
         GLORY_EDITOR_API static void SerializeComponent(Engine* pEngine, Utils::ECS::EntityRegistry* pRegistry, Utils::ECS::EntityView* pEntityView, Utils::ECS::EntityID entity, size_t index, Utils::NodeValueRef node);
-        /** @brief Deserialize a component to an entity
+        /**
+         * @brief Deserialize a component to an entity
          * @param pEngine The current engine instance
          * @param pScene The scene in which the entity exists on which to add the component
          * @param entity ID of the entity to add the component to
          * @param uuidRemapper UUID remapper to regenerate or match UUIDs with
-         * @param object The root node of the serialized component
+         * @param component Serialized component data
          * @param flags Deserialization flags
          */
-        GLORY_EDITOR_API static void DeserializeComponent(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, UUIDRemapper& uuidRemapper, Utils::NodeRef node, Flags flags = Flags(0));
+        GLORY_EDITOR_API static void DeserializeComponent(Engine* pEngine, GScene* pScene, Utils::ECS::EntityID entity, UUIDRemapper& uuidRemapper, Utils::NodeValueRef component, Flags flags = Flags(0));
     };
 }
 }

--- a/GloryEngine/Editor/GloryEditor/EntityEditor.cpp
+++ b/GloryEngine/Editor/GloryEditor/EntityEditor.cpp
@@ -1,6 +1,7 @@
 #include "EntityEditor.h"
 #include "EditableEntity.h"
 #include "EditorApplication.h"
+#include "Selection.h"
 
 #include <GScene.h>
 #include <ObjectManager.h>
@@ -49,5 +50,20 @@ namespace Glory::Editor
     void DestroyAllEditableEntities()
     {
         editableEntities.clear();
+    }
+
+    void DestroyEntity(Utils::ECS::EntityID entity, GScene* pScene)
+    {
+        auto itor = editableEntities.find(pScene->GetUUID());
+        if (itor == editableEntities.end())
+            return;
+        
+        if (itor->second.size() <= entity || !itor->second[entity])
+            return;
+
+        if (Selection::GetActiveObject() == itor->second[entity])
+            Selection::SetActiveObjectNoUndo(nullptr);
+
+        pScene->DestroyEntity(entity);
     }
 }

--- a/GloryEngine/Editor/GloryEditor/EntityEditor.h
+++ b/GloryEngine/Editor/GloryEditor/EntityEditor.h
@@ -20,5 +20,8 @@ namespace Editor
 
 	/** @brief Destroy all instances of editable entities */
 	GLORY_EDITOR_API void DestroyAllEditableEntities();
+
+	/** @brief Destroy an entity from its scene and make sure it is not selected */
+	GLORY_EDITOR_API void DestroyEntity(Utils::ECS::EntityID entity, GScene* pScene);
 }
 }

--- a/GloryEngine/Editor/GloryEditor/EntityPrefabImporter.cpp
+++ b/GloryEngine/Editor/GloryEditor/EntityPrefabImporter.cpp
@@ -28,17 +28,16 @@ namespace Glory::Editor
 	{
         Utils::YAMLFileRef yamlFile{ path };
         PrefabData* pPrefab = new PrefabData();
-		EditorSceneSerializer::DeserializeScene(EditorApplication::GetInstance()->GetEngine(), pPrefab, yamlFile.RootNodeRef().ValueRef().Node(), 0, "");
+		EditorSceneSerializer::DeserializeScene(EditorApplication::GetInstance()->GetEngine(), pPrefab, yamlFile.RootNodeRef().ValueRef(), 0, "");
         return { path, pPrefab };
 	}
 
 	bool EntityPrefabImporter::SaveResource(const std::filesystem::path& path, PrefabData* pResource) const
 	{
+		Utils::YAMLFileRef yamlFile{ path };
         YAML::Emitter out;
-        EditorSceneSerializer::SerializeScene(EditorApplication::GetInstance()->GetEngine(), pResource, out);
-        std::ofstream outFile{path};
-        outFile << out.c_str();
-        outFile.close();
+        EditorSceneSerializer::SerializeScene(EditorApplication::GetInstance()->GetEngine(), pResource, yamlFile.RootNodeRef().ValueRef());
+		yamlFile.Save();
         return true;
 	}
 

--- a/GloryEngine/Editor/GloryEditor/MaterialEditor.cpp
+++ b/GloryEngine/Editor/GloryEditor/MaterialEditor.cpp
@@ -138,7 +138,7 @@ namespace Glory::Editor
 			if (change)
 			{
 				serializers.DeserializeProperty(pMaterialData->GetBufferReference(materialManager),
-					pMaterialProperty->TypeHash(), pMaterialProperty->Offset(), pMaterialProperty->Size(), propValue.Node());
+					pMaterialProperty->TypeHash(), pMaterialProperty->Offset(), pMaterialProperty->Size(), propValue);
 			}
 		}
 

--- a/GloryEngine/Editor/GloryEditor/MaterialImporter.cpp
+++ b/GloryEngine/Editor/GloryEditor/MaterialImporter.cpp
@@ -72,7 +72,7 @@ namespace Glory::Editor
 			bool isResource = EditorApplication::GetInstance()->GetEngine()->GetResourceTypes().IsResource(pPropertyInfo->TypeHash());
 			if (!isResource)
 			{
-				EditorApplication::GetInstance()->GetEngine()->GetSerializers().SerializeProperty("Value", pMaterialData->GetBufferReference(manager), pPropertyInfo->TypeHash(), pPropertyInfo->Offset(), pPropertyInfo->Size(), property["Value"]);
+				EditorApplication::GetInstance()->GetEngine()->GetSerializers().SerializeProperty(pMaterialData->GetBufferReference(manager), pPropertyInfo->TypeHash(), pPropertyInfo->Offset(), pPropertyInfo->Size(), property["Value"]);
 			}
 			else
 			{

--- a/GloryEngine/Editor/GloryEditor/MaterialImporter.h
+++ b/GloryEngine/Editor/GloryEditor/MaterialImporter.h
@@ -18,8 +18,8 @@ namespace Glory::Editor
 		virtual ImportedResource LoadResource(const std::filesystem::path& path, void*) const override;
 		bool SaveResource(const std::filesystem::path& path, MaterialData* pResource) const override;
 
-		void SaveMaterialData(MaterialData* pMaterialData, YAML::Emitter& out) const;
-		void WritePropertyData(YAML::Emitter& out, MaterialData* pMaterialData) const;
+		void SaveMaterialData(MaterialData* pMaterialData, Utils::NodeValueRef data) const;
+		void WritePropertyData(Utils::NodeValueRef data, MaterialData* pMaterialData) const;
 
 	private:
 		virtual void Initialize() override;

--- a/GloryEngine/Editor/GloryEditor/MaterialInstanceEditor.cpp
+++ b/GloryEngine/Editor/GloryEditor/MaterialInstanceEditor.cpp
@@ -178,7 +178,7 @@ namespace Glory::Editor
 			if (!enable) continue;
 			/* Deserialize new value into buffer */
 			serializers.DeserializeProperty(pMaterialData->GetBufferReference(materialManager),
-				pMaterialProperty->TypeHash(), pMaterialProperty->Offset(), pMaterialProperty->Size(), propValue.Node());
+				pMaterialProperty->TypeHash(), pMaterialProperty->Offset(), pMaterialProperty->Size(), propValue);
 		}
 
 		if (change)

--- a/GloryEngine/Editor/GloryEditor/ObjectMenuCallbacks.cpp
+++ b/GloryEngine/Editor/GloryEditor/ObjectMenuCallbacks.cpp
@@ -49,17 +49,15 @@ namespace Glory::Editor
 		case T_SceneObject:
 		{
 			EditableEntity* pSceneObject = (EditableEntity*)pObject;
-			YAML::Emitter out;
-			out << YAML::BeginMap;
-			out << YAML::Key << "Type";
-			out << YAML::Value << "SceneObject";
-			out << YAML::Key << "Value";
-			out << YAML::Value << YAML::BeginSeq;
+			Utils::InMemoryYAML data;
+			auto objects = data.RootNodeRef().ValueRef();
+			objects.SetMap();
+			objects["Type"].Set("SceneObject");
+			auto value = objects["Value"];
+			value.SetSequence();
 			GScene* pScene = EditorApplication::GetInstance()->GetSceneManager().GetOpenScene(pSceneObject->SceneID());
-			EditorSceneSerializer::SerializeEntityRecursive(EditorApplication::GetInstance()->GetEngine(), pScene, pSceneObject->EntityID(), out);
-			out << YAML::EndSeq;
-			out << YAML::EndMap;
-			ImGui::SetClipboardText(out.c_str());
+			EditorSceneSerializer::SerializeEntityRecursive(EditorApplication::GetInstance()->GetEngine(), pScene, pSceneObject->EntityID(), value);
+			ImGui::SetClipboardText(data.ToString().c_str());
 			break;
 		}
 		case T_Resource:
@@ -109,27 +107,25 @@ namespace Glory::Editor
 		Engine* pEngine = EditorApplication::GetInstance()->GetEngine();
 
 		const char* clipboardText = ImGui::GetClipboardText();
-		YAML::Node clipboardNode;
-		try
-		{
-			clipboardNode = YAML::Load(clipboardText);
-		}
-		catch (const std::exception&)
-		{
-			pEngine->GetDebug().LogError("Pasted object is not a YAML object!");
-			return;
-		}
-		if (!clipboardNode.IsDefined() || !clipboardNode.IsMap())
+		Utils::InMemoryYAML clipboard{ clipboardText };
+		auto clipboardNode = clipboard.RootNodeRef().ValueRef();
+		if (clipboard.ParsingFailed())
 		{
 			pEngine->GetDebug().LogError("Pasted object is not a YAML object!");
 			return;
 		}
 
-		YAML::Node typeNode = clipboardNode["Type"];
-		YAML::Node valueNode = clipboardNode["Value"];
+		if (!clipboardNode.Exists() || !clipboardNode.IsMap())
+		{
+			pEngine->GetDebug().LogError("Pasted object is not a YAML object!");
+			return;
+		}
 
-		if (!typeNode.IsDefined() || !typeNode.IsScalar()) return;
-		const std::string& type = typeNode.as<std::string>();
+		auto typeNode = clipboardNode["Type"];
+		auto valueNode = clipboardNode["Value"];
+
+		if (!typeNode.Exists() || !typeNode.IsScalar()) return;
+		const std::string& type = typeNode.As<std::string>();
 
 		switch (currentMenu)
 		{
@@ -161,7 +157,7 @@ namespace Glory::Editor
 		case T_ContentBrowser:
 		{
 			if (type != "Resource" && type != "Folder") return;
-			std::filesystem::path sourcePath = valueNode["Path"].as<std::string>();
+			std::filesystem::path sourcePath = valueNode["Path"].As<std::string>();
 			std::filesystem::path destinationPath = FileBrowserItem::GetCurrentPath();
 			if (type == "Resource")
 			{

--- a/GloryEngine/Editor/GloryEditor/ObjectMenuCallbacks.cpp
+++ b/GloryEngine/Editor/GloryEditor/ObjectMenuCallbacks.cpp
@@ -225,10 +225,10 @@ namespace Glory::Editor
 		{
 			EditableEntity* pSceneObject = (EditableEntity*)pObject;
 			GScene* pScene = EditorApplication::GetInstance()->GetSceneManager().GetOpenScene(pSceneObject->SceneID());
-			if(Selection::GetActiveObject() == pSceneObject) Selection::SetActiveObject(nullptr);
 			Undo::StartRecord("Delete Object", pSceneObject->GetUUID());
 			Undo::AddAction(new DeleteSceneObjectAction(pScene, pSceneObject->EntityID()));
-			pScene->DestroyEntity(pSceneObject->EntityID());
+			if(Selection::GetActiveObject() == pSceneObject) Selection::SetActiveObjectNoUndo(nullptr);
+			DestroyEntity(pSceneObject->EntityID(), pScene);
 			Undo::StopRecord();
 			break;
 		}
@@ -296,7 +296,7 @@ namespace Glory::Editor
 			Undo::StartRecord("Create Empty Object", newEnity.EntityUUID());
 			Undo::AddAction(new CreateObjectAction(pActiveScene));
 			Undo::StopRecord();
-			Selection::SetActiveObject(GetEditableEntity(newEnity.GetEntityID(), newEnity.GetScene()));
+			Selection::SetActiveObjectNoUndo(GetEditableEntity(newEnity.GetEntityID(), newEnity.GetScene()));
 			return;
 		}
 
@@ -311,7 +311,7 @@ namespace Glory::Editor
 			Undo::StartRecord("Create Empty Object", newEntity.EntityUUID());
 			Undo::AddAction(new CreateObjectAction(pScene));
 			Undo::StopRecord();
-			Selection::SetActiveObject(GetEditableEntity(newEntity.GetEntityID(), newEntity.GetScene()));
+			Selection::SetActiveObjectNoUndo(GetEditableEntity(newEntity.GetEntityID(), newEntity.GetScene()));
 			break;
 		}
 
@@ -327,7 +327,7 @@ namespace Glory::Editor
 			Undo::AddAction(new CreateObjectAction(pScene));
 			newEntity.SetParent(pSceneObject->EntityID());
 			Undo::StopRecord();
-			Selection::SetActiveObject(GetEditableEntity(newEntity.GetEntityID(), newEntity.GetScene()));
+			Selection::SetActiveObjectNoUndo(GetEditableEntity(newEntity.GetEntityID(), newEntity.GetScene()));
 			break;
 		}
 		default:

--- a/GloryEngine/Editor/GloryEditor/RemoveComponentAction.h
+++ b/GloryEngine/Editor/GloryEditor/RemoveComponentAction.h
@@ -23,7 +23,7 @@ namespace Glory::Editor
 		virtual void OnRedo(const ActionRecord& actionRecord);
 
 	private:
-		std::string m_SerializedComponent;
+		Utils::InMemoryYAML m_SerializedComponent;
 		size_t m_ComponentIndex;
 	};
 }

--- a/GloryEngine/Editor/GloryEditor/Selection.cpp
+++ b/GloryEngine/Editor/GloryEditor/Selection.cpp
@@ -36,6 +36,18 @@ namespace Glory::Editor
 		TriggerSelectionChangeCallback();
 	}
 
+	void Selection::SetActiveObjectNoUndo(Object* pObject)
+	{
+		m_pSelectedObjects.clear();
+
+		if (pObject == nullptr)
+		{
+			TriggerSelectionChangeCallback();
+			return;
+		}
+		m_pSelectedObjects.push_back(pObject);
+	}
+
 	Object* Selection::GetActiveObject()
 	{
 		if (m_pSelectedObjects.size() <= 0) return nullptr;

--- a/GloryEngine/Editor/GloryEditor/Selection.h
+++ b/GloryEngine/Editor/GloryEditor/Selection.h
@@ -11,6 +11,7 @@ namespace Glory::Editor
 	{
 	public:
 		static GLORY_EDITOR_API void SetActiveObject(Object* pObject);
+		static GLORY_EDITOR_API void SetActiveObjectNoUndo(Object* pObject);
 		static GLORY_EDITOR_API void AddObjectToSelection(Object* pObject);
 		static GLORY_EDITOR_API void RemoveObjectFromSelection(Object* pObject);
 		static GLORY_EDITOR_API void AddObjectToSelection(UUID objectID);

--- a/GloryEngine/Editor/GloryEditor/ValueChangeAction.cpp
+++ b/GloryEngine/Editor/GloryEditor/ValueChangeAction.cpp
@@ -45,11 +45,9 @@ namespace Glory::Editor
 
 		if (!pField) return;
 
-		YAML::Emitter out;
-		out << YAML::BeginMap;
-		EditorApplication::GetInstance()->GetEngine()->GetSerializers().SerializeProperty(pField, pObject, out);
-		out << YAML::EndMap;
-		m_OldValue = YAML::Load(out.c_str());
+		auto value = m_OldValue.RootNodeRef().ValueRef();
+		value.SetMap();
+		EditorApplication::GetInstance()->GetEngine()->GetSerializers().SerializeProperty(pField, pObject, value);
 	}
 
 	void ValueChangeAction::SetNewValue(void* pObject)
@@ -77,11 +75,9 @@ namespace Glory::Editor
 
 		if (!pField) return;
 
-		YAML::Emitter out;
-		out << YAML::BeginMap;
-		EditorApplication::GetInstance()->GetEngine()->GetSerializers().SerializeProperty(pField, pObject, out);
-		out << YAML::EndMap;
-		m_NewValue = YAML::Load(out.c_str());
+		auto value = m_NewValue.RootNodeRef().ValueRef();
+		value.SetMap();
+		EditorApplication::GetInstance()->GetEngine()->GetSerializers().SerializeProperty(pField, pObject, value);
 	}
 
 	void ValueChangeAction::OnUndo(const ActionRecord& actionRecord)

--- a/GloryEngine/Editor/GloryEditor/ValueChangeAction.h
+++ b/GloryEngine/Editor/GloryEditor/ValueChangeAction.h
@@ -23,7 +23,7 @@ namespace Glory::Editor
     private:
         const Utils::Reflect::TypeData* m_pRootType;
         const std::filesystem::path m_PropertyPath;
-        YAML::Node m_OldValue;
-        YAML::Node m_NewValue;
+        Utils::InMemoryYAML m_OldValue;
+        Utils::InMemoryYAML m_NewValue;
     };
 }

--- a/GloryEngine/Engine/Core/ArrayPropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/ArrayPropertySerializer.cpp
@@ -13,23 +13,16 @@ namespace Glory
 	{
 	}
 
-	void ArrayPropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
+	void ArrayPropertySerializer::Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
-		size_t size = Reflect::ArraySize(data, typeHash);
+		const size_t size = Reflect::ArraySize(data, typeHash);
 		const TypeData* pElementTypeData = Reflect::GetTyeData(typeHash);
-
-		if (!name.empty())
-			node[name].Set(YAML::Node(YAML::NodeType::Sequence));
-		else
-			node.Set(YAML::Node(YAML::NodeType::Sequence));
+		node.Set(YAML::Node(YAML::NodeType::Sequence));
 
 		for (size_t i = 0; i < size; ++i)
 		{
 			void* pElementAddress = Reflect::ElementAddress(data, typeHash, i);
-			if (!name.empty())
-				m_pSerializers->SerializeProperty("", pElementTypeData, pElementAddress, node[name][i]);
-			else
-				m_pSerializers->SerializeProperty("", pElementTypeData, pElementAddress, node[i]);
+			m_pSerializers->SerializeProperty(pElementTypeData, pElementAddress, node[i]);
 		}
 	}
 
@@ -39,7 +32,7 @@ namespace Glory
 
 		const TypeData* pElementTypeData = Reflect::GetTyeData(typeHash);
 
-		size_t size = node.Size();
+		const size_t size = node.Size();
 		Reflect::ResizeArray(data, typeHash, size);
 		for (size_t i = 0; i < size; ++i)
 		{

--- a/GloryEngine/Engine/Core/ArrayPropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/ArrayPropertySerializer.cpp
@@ -13,37 +13,37 @@ namespace Glory
 	{
 	}
 
-	void ArrayPropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out)
+	void ArrayPropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		size_t size = Reflect::ArraySize(data, typeHash);
 		const TypeData* pElementTypeData = Reflect::GetTyeData(typeHash);
 
 		if (!name.empty())
-		{
-			out << YAML::Key << name;
-			out << YAML::Value;
-		}
+			node[name].Set(YAML::Node(YAML::NodeType::Sequence));
+		else
+			node.Set(YAML::Node(YAML::NodeType::Sequence));
 
-		out << YAML::BeginSeq;
-		for (size_t i = 0; i < size; i++)
+		for (size_t i = 0; i < size; ++i)
 		{
 			void* pElementAddress = Reflect::ElementAddress(data, typeHash, i);
-			m_pSerializers->SerializeProperty("", pElementTypeData, pElementAddress, out);
+			if (!name.empty())
+				m_pSerializers->SerializeProperty("", pElementTypeData, pElementAddress, node[name][i]);
+			else
+				m_pSerializers->SerializeProperty("", pElementTypeData, pElementAddress, node[i]);
 		}
-		out << YAML::EndSeq;
 	}
 
-	void ArrayPropertySerializer::Deserialize(void* data, uint32_t typeHash, YAML::Node& object)
+	void ArrayPropertySerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
+		if (!node.Exists() || !node.IsSequence()) return;
+
 		const TypeData* pElementTypeData = Reflect::GetTyeData(typeHash);
 
-		YAML::Node arrayNode = object;
-
-		size_t size = arrayNode.size();
+		size_t size = node.Size();
 		Reflect::ResizeArray(data, typeHash, size);
-		for (size_t i = 0; i < size; i++)
+		for (size_t i = 0; i < size; ++i)
 		{
-			YAML::Node elementNode = arrayNode[i];
+			Utils::NodeValueRef elementNode = node[i];
 			void* pElementAddress = Reflect::ElementAddress(data, typeHash, i);
 			m_pSerializers->DeserializeProperty(pElementTypeData, pElementAddress, elementNode);
 		}

--- a/GloryEngine/Engine/Core/ArrayPropertySerializer.h
+++ b/GloryEngine/Engine/Core/ArrayPropertySerializer.h
@@ -10,7 +10,7 @@ namespace Glory
         virtual ~ArrayPropertySerializer();
 
     private:
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out) override;
-        virtual void Deserialize(void* data, uint32_t typeHash, YAML::Node& object) override;
+        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/ArrayPropertySerializer.h
+++ b/GloryEngine/Engine/Core/ArrayPropertySerializer.h
@@ -10,7 +10,7 @@ namespace Glory
         virtual ~ArrayPropertySerializer();
 
     private:
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
         virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/AssetReferencePropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/AssetReferencePropertySerializer.cpp
@@ -13,24 +13,16 @@ namespace Glory
 	{
 	}
 
-	void AssetReferencePropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
+	void AssetReferencePropertySerializer::Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
-		AssetReferenceBase* pReferenceMember = (AssetReferenceBase*)data;
-		UUID uuid = pReferenceMember->AssetUUID();
-
-		if (name.empty())
-		{
-			node.Set((uint64_t)uuid);
-			return;
-		}
-
-		node[name].Set((uint64_t)uuid);
+		const AssetReferenceBase* pReferenceMember = (AssetReferenceBase*)data;
+		const UUID uuid = pReferenceMember->AssetUUID();
+		node.Set((uint64_t)uuid);
 	}
 
 	void AssetReferencePropertySerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		if (!node.Exists() || !node.IsScalar()) return;
-
 		AssetReferenceBase* pReferenceMember = (AssetReferenceBase*)data;
 		const UUID uuid = node.As<uint64_t>();
 		pReferenceMember->SetUUID(uuid);

--- a/GloryEngine/Engine/Core/AssetReferencePropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/AssetReferencePropertySerializer.cpp
@@ -13,25 +13,26 @@ namespace Glory
 	{
 	}
 
-	void AssetReferencePropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out)
+	void AssetReferencePropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		AssetReferenceBase* pReferenceMember = (AssetReferenceBase*)data;
 		UUID uuid = pReferenceMember->AssetUUID();
 
 		if (name.empty())
 		{
-			out << (uint64_t)uuid;
+			node.Set((uint64_t)uuid);
 			return;
 		}
 
-		out << YAML::Key << name;
-		out << YAML::Value << (uint64_t)uuid;
+		node[name].Set((uint64_t)uuid);
 	}
 
-	void AssetReferencePropertySerializer::Deserialize(void* data, uint32_t typeHash, YAML::Node& object)
+	void AssetReferencePropertySerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
+		if (!node.Exists() || !node.IsScalar()) return;
+
 		AssetReferenceBase* pReferenceMember = (AssetReferenceBase*)data;
-		UUID uuid = object.as<uint64_t>();
+		const UUID uuid = node.As<uint64_t>();
 		pReferenceMember->SetUUID(uuid);
 	}
 }

--- a/GloryEngine/Engine/Core/AssetReferencePropertySerializer.h
+++ b/GloryEngine/Engine/Core/AssetReferencePropertySerializer.h
@@ -10,7 +10,7 @@ namespace Glory
         virtual ~AssetReferencePropertySerializer();
 
     private:
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out) override;
-        virtual void Deserialize(void* data, uint32_t typeHash, YAML::Node& object) override;
+        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/AssetReferencePropertySerializer.h
+++ b/GloryEngine/Engine/Core/AssetReferencePropertySerializer.h
@@ -10,7 +10,7 @@ namespace Glory
         virtual ~AssetReferencePropertySerializer();
 
     private:
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
         virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/EnumPropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/EnumPropertySerializer.cpp
@@ -12,7 +12,7 @@ namespace Glory
 	{
 	}
 
-	void EnumPropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out)
+	void EnumPropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		const TypeData* pEnumTypeData = Reflect::GetTyeData(typeHash);
 		EnumType* pEnumType = Reflect::GetEnumType(typeHash);
@@ -20,19 +20,18 @@ namespace Glory
 		if(!pEnumType->ToString(data, valueString)) valueString = "none";
 		if (name.empty())
 		{
-			out << valueString;
+			node.Set(valueString);
 			return;
 		}
 
-		out << YAML::Key << name;
-		out << YAML::Value << valueString;
+		node[name].Set(valueString);
 	}
 
-	void EnumPropertySerializer::Deserialize(void* data, uint32_t typeHash, YAML::Node& object)
+	void EnumPropertySerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		const TypeData* pEnumTypeData = Reflect::GetTyeData(typeHash);
 		EnumType* pEnumType = Reflect::GetEnumType(typeHash);
-		std::string valueString = object.as<std::string>();
+		std::string valueString = node.As<std::string>();
 		pEnumType->FromString(valueString, data);
 	}
 }

--- a/GloryEngine/Engine/Core/EnumPropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/EnumPropertySerializer.cpp
@@ -12,19 +12,13 @@ namespace Glory
 	{
 	}
 
-	void EnumPropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
+	void EnumPropertySerializer::Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		const TypeData* pEnumTypeData = Reflect::GetTyeData(typeHash);
 		EnumType* pEnumType = Reflect::GetEnumType(typeHash);
 		std::string valueString;
 		if(!pEnumType->ToString(data, valueString)) valueString = "none";
-		if (name.empty())
-		{
-			node.Set(valueString);
-			return;
-		}
-
-		node[name].Set(valueString);
+		node.Set(valueString);
 	}
 
 	void EnumPropertySerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)

--- a/GloryEngine/Engine/Core/EnumPropertySerializer.h
+++ b/GloryEngine/Engine/Core/EnumPropertySerializer.h
@@ -10,7 +10,7 @@ namespace Glory
         virtual ~EnumPropertySerializer();
 
     private:
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out) override;
-        virtual void Deserialize(void* data, uint32_t typeHash, YAML::Node& object) override;
+        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/EnumPropertySerializer.h
+++ b/GloryEngine/Engine/Core/EnumPropertySerializer.h
@@ -10,7 +10,7 @@ namespace Glory
         virtual ~EnumPropertySerializer();
 
     private:
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
         virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/Object.h
+++ b/GloryEngine/Engine/Core/Object.h
@@ -5,17 +5,6 @@
 #include <typeindex>
 #include <string>
 
-/* *IDEA FOR DETECTING OBJECT INHERITENCE AND OBJECT TYPE*
-* The Object class keeps track of an array of all the inherited classes,
-* the inherited class could add itself to this aray in its constructor,
-* could be made easier with the use of a macro that generates the constructor for you,
-* this would mean that at index 0 of the array you have the last class of inheritence,
-* while the last index is the base class at the top of the hierarchy.
-* Now when searching for a specific type you check for index 0,
-* and when searching if an object is inheriting a specific class
-* you check if that type is present in the array.
-*/
-
 #define YAML_READ(startNode, node, key, out, type) node = startNode[#key]; \
 if (node.IsDefined()) out = node.as<type>()
 

--- a/GloryEngine/Engine/Core/PrefabData.cpp
+++ b/GloryEngine/Engine/Core/PrefabData.cpp
@@ -12,7 +12,7 @@
 namespace Glory
 {
 	/* @fixme Remove this when prefabs no longer require yaml data */
-	void SerializeComponent(Utils::ECS::EntityRegistry* pRegistry, Utils::ECS::EntityView* pEntityView, Utils::ECS::EntityID entity, size_t index, YAML::Emitter& out)
+	/*void SerializeComponent(Utils::ECS::EntityRegistry* pRegistry, Utils::ECS::EntityView* pEntityView, Utils::ECS::EntityID entity, size_t index, Utils::NodeValueRef node)
 	{
 		out << YAML::BeginMap;
 		const UUID compUUID = pEntityView->ComponentUUIDAt(index);
@@ -33,9 +33,9 @@ namespace Glory
 
 		GScene* pScene = pRegistry->GetUserData<GScene*>();
 		Engine* pEngine = pScene->Manager()->GetEngine();
-		pEngine->GetSerializers().SerializeProperty("Properties", pType, pRegistry->GetComponentAddress(entity, compUUID), out);
+		pEngine->GetSerializers().SerializeProperty("Properties", pType, pRegistry->GetComponentAddress(entity, compUUID), node);
 		out << YAML::EndMap;
-	}
+	}*/
 
 	PrefabData::PrefabData()
 	{

--- a/GloryEngine/Engine/Core/PropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/PropertySerializer.cpp
@@ -16,11 +16,11 @@ namespace Glory
 		return m_TypeHash;
 	}
 
-	void PropertySerializer::Serialize(const std::string&, const std::vector<char>&, uint32_t, size_t, size_t, YAML::Emitter&) {}
+	void PropertySerializer::Serialize(const std::string&, const std::vector<char>&, uint32_t, size_t, size_t, Utils::NodeValueRef) {}
 
-	void PropertySerializer::Serialize(const std::string&, void*, uint32_t, YAML::Emitter&) {}
+	void PropertySerializer::Serialize(const std::string&, void*, uint32_t, Utils::NodeValueRef) {}
 
-	void PropertySerializer::Deserialize(std::vector<char>&, size_t, size_t, YAML::Node&) {}
+	void PropertySerializer::Deserialize(std::vector<char>&, size_t, size_t, Utils::NodeValueRef) {}
 
-	void PropertySerializer::Deserialize(void* data, uint32_t typeHash, YAML::Node& object) {}
+	void PropertySerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef) {}
 }

--- a/GloryEngine/Engine/Core/PropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/PropertySerializer.cpp
@@ -16,9 +16,9 @@ namespace Glory
 		return m_TypeHash;
 	}
 
-	void PropertySerializer::Serialize(const std::string&, const std::vector<char>&, uint32_t, size_t, size_t, Utils::NodeValueRef) {}
+	void PropertySerializer::Serialize(const std::vector<char>&, uint32_t, size_t, size_t, Utils::NodeValueRef) {}
 
-	void PropertySerializer::Serialize(const std::string&, void*, uint32_t, Utils::NodeValueRef) {}
+	void PropertySerializer::Serialize(void*, uint32_t, Utils::NodeValueRef) {}
 
 	void PropertySerializer::Deserialize(std::vector<char>&, size_t, size_t, Utils::NodeValueRef) {}
 

--- a/GloryEngine/Engine/Core/PropertySerializer.h
+++ b/GloryEngine/Engine/Core/PropertySerializer.h
@@ -19,10 +19,10 @@ namespace Glory
 		virtual ~PropertySerializer();
 
 	public:
-		virtual void Serialize(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node);
+		virtual void Serialize(const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node);
 		virtual void Deserialize(std::vector<char>& buffer, size_t offset, size_t size, Utils::NodeValueRef node);
 		
-		virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node);
+		virtual void Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node);
 		virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node);
 
 	protected:
@@ -45,11 +45,11 @@ namespace Glory
 		virtual ~SimpleTemplatedPropertySerializer() {}
 
 	private:
-		virtual void Serialize(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node) override
+		virtual void Serialize(const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node) override
 		{
 			T value;
 			memcpy((void*)&value, (void*)&buffer[offset], size);
-			node[name].Set(value);
+			node.Set(value);
 		}
 
 		virtual void Deserialize(std::vector<char>& buffer, size_t offset, size_t size, Utils::NodeValueRef node) override
@@ -59,17 +59,10 @@ namespace Glory
 			memcpy((void*)&buffer[offset], (void*)&value, size);
 		}
 
-		virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override
+		virtual void Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override
 		{
 			T* value = (T*)data;
-			/* Nameless properties can come from array elements */
-			if (name.empty())
-			{
-				node.Set(*value);
-				return;
-			}
-
-			node[name].Set(*value);
+			node.Set(*value);
 		}
 
 		virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override

--- a/GloryEngine/Engine/Core/SceneObjectRefSerializer.cpp
+++ b/GloryEngine/Engine/Core/SceneObjectRefSerializer.cpp
@@ -2,39 +2,37 @@
 
 namespace Glory
 {
-	void SceneObjectRefSerializer::Serialize(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, YAML::Emitter& out)
+	void SceneObjectRefSerializer::Serialize(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node)
 	{
 		SceneObjectRef value;
 		memcpy((void*)&value, (void*)&buffer[offset], size);
-		out << YAML::Key << name;
-		out << YAML::Value << value;
+		node[name].Set(value);
 	}
 
-	void SceneObjectRefSerializer::Deserialize(std::vector<char>& buffer, size_t offset, size_t size, YAML::Node& object)
+	void SceneObjectRefSerializer::Deserialize(std::vector<char>& buffer, size_t offset, size_t size, Utils::NodeValueRef node)
 	{
-		if (!object.IsDefined()) return;
-		SceneObjectRef value = object.as<SceneObjectRef>();
+		if (!node.Exists() || !node.IsMap()) return;
+		SceneObjectRef value = node.As<SceneObjectRef>();
 		memcpy((void*)&buffer[offset], (void*)&value, size);
 	}
 
-	void SceneObjectRefSerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out)
+	void SceneObjectRefSerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		SceneObjectRef* value = (SceneObjectRef*)data;
 
 		if (name.empty())
 		{
-			out << *value;
+			node.Set(*value);
 			return;
 		}
 
-		out << YAML::Key << name;
-		out << YAML::Value << *value;
+		node[name].Set(*value);
 	}
 
-	void SceneObjectRefSerializer::Deserialize(void* data, uint32_t typeHash, YAML::Node& object)
+	void SceneObjectRefSerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
-		if (!object.IsDefined()) return;
+		if (!node.Exists() || !node.IsMap()) return;
 		SceneObjectRef* value = (SceneObjectRef*)data;
-		*value = object.as<SceneObjectRef>();
+		*value = node.As<SceneObjectRef>();
 	}
 }

--- a/GloryEngine/Engine/Core/SceneObjectRefSerializer.cpp
+++ b/GloryEngine/Engine/Core/SceneObjectRefSerializer.cpp
@@ -2,11 +2,11 @@
 
 namespace Glory
 {
-	void SceneObjectRefSerializer::Serialize(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node)
+	void SceneObjectRefSerializer::Serialize(const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node)
 	{
 		SceneObjectRef value;
 		memcpy((void*)&value, (void*)&buffer[offset], size);
-		node[name].Set(value);
+		node.Set(value);
 	}
 
 	void SceneObjectRefSerializer::Deserialize(std::vector<char>& buffer, size_t offset, size_t size, Utils::NodeValueRef node)
@@ -16,17 +16,10 @@ namespace Glory
 		memcpy((void*)&buffer[offset], (void*)&value, size);
 	}
 
-	void SceneObjectRefSerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
+	void SceneObjectRefSerializer::Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		SceneObjectRef* value = (SceneObjectRef*)data;
-
-		if (name.empty())
-		{
-			node.Set(*value);
-			return;
-		}
-
-		node[name].Set(*value);
+		node.Set(*value);
 	}
 
 	void SceneObjectRefSerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)

--- a/GloryEngine/Engine/Core/SceneObjectRefSerializer.h
+++ b/GloryEngine/Engine/Core/SceneObjectRefSerializer.h
@@ -9,9 +9,9 @@ namespace Glory
         SceneObjectRefSerializer(Serializers* pSerializers) : PropertySerializer(pSerializers, SerializedType::ST_Object) {}
 
     private:
-        virtual void Serialize(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, YAML::Emitter& out) override;
-        virtual void Deserialize(std::vector<char>& buffer, size_t offset, size_t size, YAML::Node& object) override;
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out) override;
-        virtual void Deserialize(void* data, uint32_t typeHash, YAML::Node& object) override;
+        virtual void Serialize(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node) override;
+        virtual void Deserialize(std::vector<char>& buffer, size_t offset, size_t size, Utils::NodeValueRef node) override;
+        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/SceneObjectRefSerializer.h
+++ b/GloryEngine/Engine/Core/SceneObjectRefSerializer.h
@@ -9,9 +9,9 @@ namespace Glory
         SceneObjectRefSerializer(Serializers* pSerializers) : PropertySerializer(pSerializers, SerializedType::ST_Object) {}
 
     private:
-        virtual void Serialize(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node) override;
+        virtual void Serialize(const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node) override;
         virtual void Deserialize(std::vector<char>& buffer, size_t offset, size_t size, Utils::NodeValueRef node) override;
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
         virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/Serializers.cpp
+++ b/GloryEngine/Engine/Core/Serializers.cpp
@@ -44,98 +44,98 @@ namespace Glory
 		return 0;
 	}
 
-	void Serializers::SerializeProperty(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, YAML::Emitter& out)
+	void Serializers::SerializeProperty(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node)
 	{
 		PropertySerializer* pSerializer = GetSerializer(typeHash);
 		if (pSerializer == nullptr) return;
-		pSerializer->Serialize(name, buffer, typeHash, offset, size, out);
+		pSerializer->Serialize(name, buffer, typeHash, offset, size, node);
 	}
 
-	void Serializers::DeserializeProperty(std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, YAML::Node& object)
+	void Serializers::DeserializeProperty(std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node)
 	{
 		PropertySerializer* pSerializer = GetSerializer(typeHash);
 		if (pSerializer == nullptr) return;
-		pSerializer->Deserialize(buffer, offset, size, object);
+		pSerializer->Deserialize(buffer, offset, size, node);
 	}
 
-	void Serializers::SerializeProperty(const std::string& name, const Utils::Reflect::TypeData* pTypeData, void* data, YAML::Emitter& out)
+	void Serializers::SerializeProperty(const std::string& name, const Utils::Reflect::TypeData* pTypeData, void* data, Utils::NodeValueRef node)
 	{
 		PropertySerializer* pSerializer = GetSerializer(pTypeData->TypeHash());
 		PropertySerializer* pInternalSerializer = GetSerializer(pTypeData->InternalTypeHash());
 		if (pSerializer)
 		{
-			pSerializer->Serialize(name, data, pTypeData->TypeHash(), out);
+			pSerializer->Serialize(name, data, pTypeData->TypeHash(), node);
 			return;
 		}
 		if (pInternalSerializer)
 		{
-			pInternalSerializer->Serialize(name, data, pTypeData->TypeHash(), out);
+			pInternalSerializer->Serialize(name, data, pTypeData->TypeHash(), node);
 			return;
 		}
 
 		throw new std::exception("Missing serializer!");
 	}
 
-	void Serializers::SerializeProperty(const FieldData* pFieldData, void* data, YAML::Emitter& out)
+	void Serializers::SerializeProperty(const FieldData* pFieldData, void* data, Utils::NodeValueRef node)
 	{
 		if (pFieldData->Type() == ST_Array)
 		{
-			return GetSerializer(ST_Array)->Serialize(pFieldData->Name(), data, pFieldData->ArrayElementType(), out);
+			return GetSerializer(ST_Array)->Serialize(pFieldData->Name(), data, pFieldData->ArrayElementType(), node);
 		}
 
 		const Utils::Reflect::TypeData* pTypeData = Reflect::GetTyeData(pFieldData->ArrayElementType());
 		if (pTypeData)
 		{
-			SerializeProperty(pFieldData->Name(), pTypeData, data, out);
+			SerializeProperty(pFieldData->Name(), pTypeData, data, node);
 			return;
 		}
 
 		PropertySerializer* pSerializer = GetSerializer(pFieldData->Type());
 		if (pSerializer)
 		{
-			pSerializer->Serialize(pFieldData->Name(), data, pFieldData->Type(), out);
+			pSerializer->Serialize(pFieldData->Name(), data, pFieldData->Type(), node);
 			return;
 		}
 
 		throw new std::exception("Missing serializer!");
 	}
 
-	void Serializers::DeserializeProperty(const Utils::Reflect::TypeData* pTypeData, void* data, YAML::Node& object)
+	void Serializers::DeserializeProperty(const Utils::Reflect::TypeData* pTypeData, void* data, Utils::NodeValueRef node)
 	{
 		PropertySerializer* pSerializer = GetSerializer(pTypeData->TypeHash());
 		PropertySerializer* pInternalSerializer = GetSerializer(pTypeData->InternalTypeHash());
 		if (pSerializer)
 		{
-			pSerializer->Deserialize(data, pTypeData->TypeHash(), object);
+			pSerializer->Deserialize(data, pTypeData->TypeHash(), node);
 			return;
 		}
 		if (pInternalSerializer)
 		{
-			pInternalSerializer->Deserialize(data, pTypeData->TypeHash(), object);
+			pInternalSerializer->Deserialize(data, pTypeData->TypeHash(), node);
 			return;
 		}
 
 		throw new std::exception("Missing serializer!");
 	}
 
-	void Serializers::DeserializeProperty(const FieldData* pFieldData, void* data, YAML::Node& object)
+	void Serializers::DeserializeProperty(const FieldData* pFieldData, void* data, Utils::NodeValueRef node)
 	{
 		if (pFieldData->Type() == ST_Array)
 		{
-			return GetSerializer(ST_Array)->Deserialize(data, pFieldData->ArrayElementType(), object);
+			return GetSerializer(ST_Array)->Deserialize(data, pFieldData->ArrayElementType(), node);
 		}
 
 		const Utils::Reflect::TypeData* pTypeData = Reflect::GetTyeData(pFieldData->ArrayElementType());
 		if (pTypeData)
 		{
-			DeserializeProperty(pTypeData, data, object);
+			DeserializeProperty(pTypeData, data, node);
 			return;
 		}
 
 		PropertySerializer* pSerializer = GetSerializer(pFieldData->Type());
 		if (pSerializer)
 		{
-			pSerializer->Deserialize(data, pFieldData->Type(), object);
+			pSerializer->Deserialize(data, pFieldData->Type(), node);
 			return;
 		}
 

--- a/GloryEngine/Engine/Core/Serializers.cpp
+++ b/GloryEngine/Engine/Core/Serializers.cpp
@@ -44,11 +44,11 @@ namespace Glory
 		return 0;
 	}
 
-	void Serializers::SerializeProperty(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node)
+	void Serializers::SerializeProperty(const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node)
 	{
 		PropertySerializer* pSerializer = GetSerializer(typeHash);
 		if (pSerializer == nullptr) return;
-		pSerializer->Serialize(name, buffer, typeHash, offset, size, node);
+		pSerializer->Serialize(buffer, typeHash, offset, size, node);
 	}
 
 	void Serializers::DeserializeProperty(std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node)
@@ -58,18 +58,18 @@ namespace Glory
 		pSerializer->Deserialize(buffer, offset, size, node);
 	}
 
-	void Serializers::SerializeProperty(const std::string& name, const Utils::Reflect::TypeData* pTypeData, void* data, Utils::NodeValueRef node)
+	void Serializers::SerializeProperty(const Utils::Reflect::TypeData* pTypeData, void* data, Utils::NodeValueRef node)
 	{
 		PropertySerializer* pSerializer = GetSerializer(pTypeData->TypeHash());
 		PropertySerializer* pInternalSerializer = GetSerializer(pTypeData->InternalTypeHash());
 		if (pSerializer)
 		{
-			pSerializer->Serialize(name, data, pTypeData->TypeHash(), node);
+			pSerializer->Serialize(data, pTypeData->TypeHash(), node);
 			return;
 		}
 		if (pInternalSerializer)
 		{
-			pInternalSerializer->Serialize(name, data, pTypeData->TypeHash(), node);
+			pInternalSerializer->Serialize(data, pTypeData->TypeHash(), node);
 			return;
 		}
 
@@ -80,20 +80,20 @@ namespace Glory
 	{
 		if (pFieldData->Type() == ST_Array)
 		{
-			return GetSerializer(ST_Array)->Serialize(pFieldData->Name(), data, pFieldData->ArrayElementType(), node);
+			return GetSerializer(ST_Array)->Serialize(data, pFieldData->ArrayElementType(), node);
 		}
 
 		const Utils::Reflect::TypeData* pTypeData = Reflect::GetTyeData(pFieldData->ArrayElementType());
 		if (pTypeData)
 		{
-			SerializeProperty(pFieldData->Name(), pTypeData, data, node);
+			SerializeProperty(pTypeData, data, node);
 			return;
 		}
 
 		PropertySerializer* pSerializer = GetSerializer(pFieldData->Type());
 		if (pSerializer)
 		{
-			pSerializer->Serialize(pFieldData->Name(), data, pFieldData->Type(), node);
+			pSerializer->Serialize(data, pFieldData->Type(), node);
 			return;
 		}
 

--- a/GloryEngine/Engine/Core/Serializers.cpp
+++ b/GloryEngine/Engine/Core/Serializers.cpp
@@ -53,6 +53,8 @@ namespace Glory
 
 	void Serializers::DeserializeProperty(std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node)
 	{
+		if (!node.Exists()) return;
+
 		PropertySerializer* pSerializer = GetSerializer(typeHash);
 		if (pSerializer == nullptr) return;
 		pSerializer->Deserialize(buffer, offset, size, node);
@@ -102,6 +104,8 @@ namespace Glory
 
 	void Serializers::DeserializeProperty(const Utils::Reflect::TypeData* pTypeData, void* data, Utils::NodeValueRef node)
 	{
+		if (!node.Exists()) return;
+
 		PropertySerializer* pSerializer = GetSerializer(pTypeData->TypeHash());
 		PropertySerializer* pInternalSerializer = GetSerializer(pTypeData->InternalTypeHash());
 		if (pSerializer)
@@ -120,6 +124,8 @@ namespace Glory
 
 	void Serializers::DeserializeProperty(const FieldData* pFieldData, void* data, Utils::NodeValueRef node)
 	{
+		if (!node.Exists()) return;
+
 		if (pFieldData->Type() == ST_Array)
 		{
 			return GetSerializer(ST_Array)->Deserialize(data, pFieldData->ArrayElementType(), node);

--- a/GloryEngine/Engine/Core/Serializers.h
+++ b/GloryEngine/Engine/Core/Serializers.h
@@ -37,10 +37,10 @@ namespace Glory
 		PropertySerializer* GetSerializer(uint32_t typeHash);
 		size_t GetID(PropertySerializer* pSerializer);
 
-		void SerializeProperty(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node);
+		void SerializeProperty(const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node);
 		void DeserializeProperty(std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node);
 
-		void SerializeProperty(const std::string& name, const Utils::Reflect::TypeData* pTypeData, void* data, Utils::NodeValueRef node);
+		void SerializeProperty(const Utils::Reflect::TypeData* pTypeData, void* data, Utils::NodeValueRef node);
 		void SerializeProperty(const Utils::Reflect::FieldData* pFieldData, void* data, Utils::NodeValueRef node);
 		void DeserializeProperty(const Utils::Reflect::TypeData* pTypeData, void* data, Utils::NodeValueRef node);
 		void DeserializeProperty(const Utils::Reflect::FieldData* pFieldData, void* data, Utils::NodeValueRef node);

--- a/GloryEngine/Engine/Core/Serializers.h
+++ b/GloryEngine/Engine/Core/Serializers.h
@@ -2,6 +2,8 @@
 #include <vector>
 #include <string>
 
+#include <NodeRef.h>
+
 namespace YAML
 {
 	class Node;
@@ -35,13 +37,13 @@ namespace Glory
 		PropertySerializer* GetSerializer(uint32_t typeHash);
 		size_t GetID(PropertySerializer* pSerializer);
 
-		void SerializeProperty(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, YAML::Emitter& out);
-		void DeserializeProperty(std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, YAML::Node& object);
+		void SerializeProperty(const std::string& name, const std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node);
+		void DeserializeProperty(std::vector<char>& buffer, uint32_t typeHash, size_t offset, size_t size, Utils::NodeValueRef node);
 
-		void SerializeProperty(const std::string& name, const Utils::Reflect::TypeData* pTypeData, void* data, YAML::Emitter& out);
-		void SerializeProperty(const Utils::Reflect::FieldData* pFieldData, void* data, YAML::Emitter& out);
-		void DeserializeProperty(const Utils::Reflect::TypeData* pTypeData, void* data, YAML::Node& object);
-		void DeserializeProperty(const Utils::Reflect::FieldData* pFieldData, void* data, YAML::Node& object);
+		void SerializeProperty(const std::string& name, const Utils::Reflect::TypeData* pTypeData, void* data, Utils::NodeValueRef node);
+		void SerializeProperty(const Utils::Reflect::FieldData* pFieldData, void* data, Utils::NodeValueRef node);
+		void DeserializeProperty(const Utils::Reflect::TypeData* pTypeData, void* data, Utils::NodeValueRef node);
+		void DeserializeProperty(const Utils::Reflect::FieldData* pFieldData, void* data, Utils::NodeValueRef node);
 
 		Engine* GetEngine() const;
 

--- a/GloryEngine/Engine/Core/ShapePropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/ShapePropertySerializer.cpp
@@ -45,7 +45,7 @@ namespace Glory
 			T* pShape = shapeProperty->ShapePointer<T>();
 
 			const TypeData* pTypeData = Reflect::GetTyeData(ResourceTypes::GetHash<T>());
-			pSerializers->SerializeProperty("Shape", pTypeData, pShape, node);
+			pSerializers->SerializeProperty(pTypeData, pShape, node["Shape"]);
 		}
 
 		void DeserializeInternal(Serializers* pSerializers, ShapeProperty* shapeProperty, Utils::NodeValueRef node) const override
@@ -77,15 +77,12 @@ namespace Glory
 	ShapePropertySerializer::ShapePropertySerializer(Serializers* pSerializers):
 		PropertySerializer(pSerializers, ResourceTypes::GetHash<ShapeProperty>()) {}
 
-	void ShapePropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
+	void ShapePropertySerializer::Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		ShapeProperty* value = (ShapeProperty*)data;
-
-		Utils::NodeValueRef mapNode = name.empty() ? node : node[name];
-		mapNode.Set(YAML::Node(YAML::NodeType::Map));
-
-		mapNode["ShapeType"].SetEnum(value->m_ShapeType);
-		ShapeSerializers::Serialize(m_pSerializers, value, mapNode);
+		node.Set(YAML::Node(YAML::NodeType::Map));
+		node["ShapeType"].SetEnum(value->m_ShapeType);
+		ShapeSerializers::Serialize(m_pSerializers, value, node);
 	}
 
 	void ShapePropertySerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)

--- a/GloryEngine/Engine/Core/ShapePropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/ShapePropertySerializer.cpp
@@ -7,16 +7,16 @@ namespace Glory
 	class ShapeSerializers
 	{
 	public:
-		static void Serialize(Serializers* pSerializers, ShapeProperty* shapeProperty, YAML::Emitter& out)
+		static void Serialize(Serializers* pSerializers, ShapeProperty* shapeProperty, Utils::NodeValueRef node)
 		{
 			if (SHAPE_SERIALIZERS.find(shapeProperty->m_ShapeType) == SHAPE_SERIALIZERS.end()) return;
-			SHAPE_SERIALIZERS.at(shapeProperty->m_ShapeType)->SerializeInternal(pSerializers, shapeProperty, out);
+			SHAPE_SERIALIZERS.at(shapeProperty->m_ShapeType)->SerializeInternal(pSerializers, shapeProperty, node);
 		}
 
-		static void Deserialize(Serializers* pSerializers, const ShapeType shapeType, ShapeProperty* shapeProperty, YAML::Node& object)
+		static void Deserialize(Serializers* pSerializers, const ShapeType shapeType, ShapeProperty* shapeProperty, Utils::NodeValueRef node)
 		{
 			if (SHAPE_SERIALIZERS.find(shapeType) == SHAPE_SERIALIZERS.end()) return;
-			SHAPE_SERIALIZERS.at(shapeType)->DeserializeInternal(pSerializers, shapeProperty, object);
+			SHAPE_SERIALIZERS.at(shapeType)->DeserializeInternal(pSerializers, shapeProperty, node);
 		}
 
 		static void Cleanup()
@@ -29,8 +29,8 @@ namespace Glory
 		}
 
 	protected:
-		virtual void SerializeInternal(Serializers* pSerializers, ShapeProperty* shapeProperty, YAML::Emitter& out) const = 0;
-		virtual void DeserializeInternal(Serializers* pSerializers, ShapeProperty* shapeProperty, YAML::Node& object) const = 0;
+		virtual void SerializeInternal(Serializers* pSerializers, ShapeProperty* shapeProperty, Utils::NodeValueRef node) const = 0;
+		virtual void DeserializeInternal(Serializers* pSerializers, ShapeProperty* shapeProperty, Utils::NodeValueRef node) const = 0;
 
 	private:
 		static std::map<ShapeType, ShapeSerializers*> SHAPE_SERIALIZERS;
@@ -40,21 +40,21 @@ namespace Glory
 	class ShapeSerializer : public ShapeSerializers
 	{
 	private:
-		void SerializeInternal(Serializers* pSerializers, ShapeProperty* shapeProperty, YAML::Emitter& out) const override
+		void SerializeInternal(Serializers* pSerializers, ShapeProperty* shapeProperty, Utils::NodeValueRef node) const override
 		{
 			T* pShape = shapeProperty->ShapePointer<T>();
 
 			const TypeData* pTypeData = Reflect::GetTyeData(ResourceTypes::GetHash<T>());
-			pSerializers->SerializeProperty("Shape", pTypeData, pShape, out);
+			pSerializers->SerializeProperty("Shape", pTypeData, pShape, node);
 		}
 
-		void DeserializeInternal(Serializers* pSerializers, ShapeProperty* shapeProperty, YAML::Node& object) const override
+		void DeserializeInternal(Serializers* pSerializers, ShapeProperty* shapeProperty, Utils::NodeValueRef node) const override
 		{
 			shapeProperty->SetShape<T>(T());
 
 			T* pShape = shapeProperty->ShapePointer<T>();
 
-			YAML::Node shape = object["Shape"];
+			auto shape = node["Shape"];
 			const TypeData* pTypeData = Reflect::GetTyeData(ResourceTypes::GetHash<T>());
 			pSerializers->DeserializeProperty(pTypeData, pShape, shape);
 		}
@@ -77,34 +77,24 @@ namespace Glory
 	ShapePropertySerializer::ShapePropertySerializer(Serializers* pSerializers):
 		PropertySerializer(pSerializers, ResourceTypes::GetHash<ShapeProperty>()) {}
 
-	void ShapePropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out)
+	void ShapePropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		ShapeProperty* value = (ShapeProperty*)data;
-		std::string shapeType;
-		if (!Enum<ShapeType>().ToString(value->m_ShapeType, shapeType)) return;
 
-		if (!name.empty())
-		{
-			out << YAML::Key << name;
-			out << YAML::Value;
-		}
+		Utils::NodeValueRef mapNode = name.empty() ? node : node[name];
+		mapNode.Set(YAML::Node(YAML::NodeType::Map));
 
-		out << YAML::BeginMap;
-		out << YAML::Key << "ShapeType";
-		out << YAML::Value << shapeType;
-		ShapeSerializers::Serialize(m_pSerializers, value, out);
-		out << YAML::EndMap;
+		mapNode["ShapeType"].SetEnum(value->m_ShapeType);
+		ShapeSerializers::Serialize(m_pSerializers, value, mapNode);
 	}
 
-	void ShapePropertySerializer::Deserialize(void* data, uint32_t typeHash, YAML::Node& object)
+	void ShapePropertySerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
-		if (!object.IsDefined()) return;
-		YAML::Node shapeTypeNode = object["ShapeType"];
-		std::string shapeTypeStr = shapeTypeNode.as<std::string>();
-		ShapeType shapeTye;
-		if (!Enum<ShapeType>().FromString(shapeTypeStr, shapeTye)) return;
+		if (!node.Exists() || !node.IsMap()) return;
+		auto shapeTypeNode = node["ShapeType"];
+		const ShapeType shapeTye = shapeTypeNode.AsEnum<ShapeType>();
 
 		ShapeProperty* value = (ShapeProperty*)data;
-		ShapeSerializers::Deserialize(m_pSerializers, shapeTye, value, object);
+		ShapeSerializers::Deserialize(m_pSerializers, shapeTye, value, node);
 	}
 }

--- a/GloryEngine/Engine/Core/ShapePropertySerializer.h
+++ b/GloryEngine/Engine/Core/ShapePropertySerializer.h
@@ -10,7 +10,7 @@ namespace Glory
 		virtual ~ShapePropertySerializer();
 
 	private:
-		void Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out) override;
-		void Deserialize(void* data, uint32_t typeHash, YAML::Node& object) override;
+		void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+		void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/ShapePropertySerializer.h
+++ b/GloryEngine/Engine/Core/ShapePropertySerializer.h
@@ -10,7 +10,7 @@ namespace Glory
 		virtual ~ShapePropertySerializer();
 
 	private:
-		void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+		void Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
 		void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/StructPropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/StructPropertySerializer.cpp
@@ -28,7 +28,7 @@ namespace Glory
 			size_t offset = pSubFieldData->Offset();
 			void* pAddress = (void*)((char*)(data)+offset);
 			if (!name.empty())
-				m_pSerializers->SerializeProperty(pSubFieldData, pAddress, node[name][pSubFieldData->Name()]);
+				m_pSerializers->SerializeProperty(pSubFieldData, pAddress, node[name]);
 			else
 				m_pSerializers->SerializeProperty(pSubFieldData, pAddress, node[pSubFieldData->Name()]);
 		}

--- a/GloryEngine/Engine/Core/StructPropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/StructPropertySerializer.cpp
@@ -13,37 +13,38 @@ namespace Glory
 	{
 	}
 
-	void StructPropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out)
+	void StructPropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		const TypeData* pStructTypeData = Reflect::GetTyeData(typeHash);
 
 		if (!name.empty())
-		{
-			out << YAML::Key << name;
-			out << YAML::Value;
-		}
+			node[name].Set(YAML::Node(YAML::NodeType::Map));
+		else
+			node.Set(YAML::Node(YAML::NodeType::Map));
 
-		out << YAML::BeginMap;
-		for (size_t i = 0; i < pStructTypeData->FieldCount(); i++)
+		for (size_t i = 0; i < pStructTypeData->FieldCount(); ++i)
 		{
 			const FieldData* pSubFieldData = pStructTypeData->GetFieldData(i);
 			size_t offset = pSubFieldData->Offset();
 			void* pAddress = (void*)((char*)(data)+offset);
-			m_pSerializers->SerializeProperty(pSubFieldData, pAddress, out);
+			if (!name.empty())
+				m_pSerializers->SerializeProperty(pSubFieldData, pAddress, node[name][pSubFieldData->Name()]);
+			else
+				m_pSerializers->SerializeProperty(pSubFieldData, pAddress, node[pSubFieldData->Name()]);
 		}
-		out << YAML::EndMap;
 	}
 
-	void StructPropertySerializer::Deserialize(void* data, uint32_t typeHash, YAML::Node& object)
+	void StructPropertySerializer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
+		if (!node.Exists() || !node.IsMap()) return;
 		const TypeData* pStructTypeData = Reflect::GetTyeData(typeHash);
-		for (size_t i = 0; i < pStructTypeData->FieldCount(); i++)
+		for (size_t i = 0; i < pStructTypeData->FieldCount(); ++i)
 		{
 			const FieldData* pSubFieldData = pStructTypeData->GetFieldData(i);
 			size_t offset = pSubFieldData->Offset();
 			void* pAddress = (void*)((char*)(data)+offset);
 
-			YAML::Node structFieldObject = object[pSubFieldData->Name()];
+			Utils::NodeValueRef structFieldObject = node[pSubFieldData->Name()];
 			m_pSerializers->DeserializeProperty(pSubFieldData, pAddress, structFieldObject);
 		}
 	}

--- a/GloryEngine/Engine/Core/StructPropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/StructPropertySerializer.cpp
@@ -24,7 +24,8 @@ namespace Glory
 			const FieldData* pSubFieldData = pStructTypeData->GetFieldData(i);
 			size_t offset = pSubFieldData->Offset();
 			void* pAddress = (void*)((char*)(data)+offset);
-			m_pSerializers->SerializeProperty(pSubFieldData, pAddress, node[pSubFieldData->Name()]);
+			Utils::NodeValueRef structFieldObject = node[pSubFieldData->Name()];
+			m_pSerializers->SerializeProperty(pSubFieldData, pAddress, structFieldObject);
 		}
 	}
 

--- a/GloryEngine/Engine/Core/StructPropertySerializer.cpp
+++ b/GloryEngine/Engine/Core/StructPropertySerializer.cpp
@@ -13,24 +13,18 @@ namespace Glory
 	{
 	}
 
-	void StructPropertySerializer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
+	void StructPropertySerializer::Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		const TypeData* pStructTypeData = Reflect::GetTyeData(typeHash);
 
-		if (!name.empty())
-			node[name].Set(YAML::Node(YAML::NodeType::Map));
-		else
-			node.Set(YAML::Node(YAML::NodeType::Map));
+		node.Set(YAML::Node(YAML::NodeType::Map));
 
 		for (size_t i = 0; i < pStructTypeData->FieldCount(); ++i)
 		{
 			const FieldData* pSubFieldData = pStructTypeData->GetFieldData(i);
 			size_t offset = pSubFieldData->Offset();
 			void* pAddress = (void*)((char*)(data)+offset);
-			if (!name.empty())
-				m_pSerializers->SerializeProperty(pSubFieldData, pAddress, node[name]);
-			else
-				m_pSerializers->SerializeProperty(pSubFieldData, pAddress, node[pSubFieldData->Name()]);
+			m_pSerializers->SerializeProperty(pSubFieldData, pAddress, node[pSubFieldData->Name()]);
 		}
 	}
 

--- a/GloryEngine/Engine/Core/StructPropertySerializer.h
+++ b/GloryEngine/Engine/Core/StructPropertySerializer.h
@@ -10,7 +10,7 @@ namespace Glory
         virtual ~StructPropertySerializer();
 
     private:
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out) override;
-        virtual void Deserialize(void* data, uint32_t typeHash, YAML::Node& object) override;
+        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Engine/Core/StructPropertySerializer.h
+++ b/GloryEngine/Engine/Core/StructPropertySerializer.h
@@ -10,7 +10,7 @@ namespace Glory
         virtual ~StructPropertySerializer();
 
     private:
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
         virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
     };
 }

--- a/GloryEngine/Modules/GloryMonoScripting/ScriptedComponentSerializer.cpp
+++ b/GloryEngine/Modules/GloryMonoScripting/ScriptedComponentSerializer.cpp
@@ -15,13 +15,12 @@ namespace Glory
 	{
 	}
 
-	void ScriptedComponentSerailizer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
+	void ScriptedComponentSerailizer::Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		MonoScriptComponent* pScriptedComponent = (MonoScriptComponent*)data;
-		auto properties = node["Properties"];
-		properties.Set(YAML::Node(YAML::NodeType::Map));
-		properties["m_Script"].Set(uint64_t(pScriptedComponent->m_Script.AssetUUID()));
-		auto scriptData = properties["ScriptData"];
+		node.Set(YAML::Node(YAML::NodeType::Map));
+		node["m_Script"].Set(uint64_t(pScriptedComponent->m_Script.AssetUUID()));
+		auto scriptData = node["ScriptData"];
 		scriptData.Set(YAML::Node(YAML::NodeType::Map));
 
 		MonoScript* pScript = pScriptedComponent->m_Script.GetImmediate(&m_pSerializers->GetEngine()->GetAssetManager());
@@ -34,7 +33,7 @@ namespace Glory
 			{
 				const ScriptProperty& prop = props[i];
 				const TypeData* pType = Reflect::GetTyeData(prop.m_TypeHash);
-				m_pSerializers->SerializeProperty(prop.m_Name, pType, &pScriptedComponent->m_ScriptData.m_Buffer[prop.m_RelativeOffset], scriptData);
+				m_pSerializers->SerializeProperty(pType, &pScriptedComponent->m_ScriptData.m_Buffer[prop.m_RelativeOffset], scriptData[prop.m_Name]);
 			}
 		}
 	}

--- a/GloryEngine/Modules/GloryMonoScripting/ScriptedComponentSerializer.cpp
+++ b/GloryEngine/Modules/GloryMonoScripting/ScriptedComponentSerializer.cpp
@@ -15,13 +15,14 @@ namespace Glory
 	{
 	}
 
-	void ScriptedComponentSerailizer::Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out)
+	void ScriptedComponentSerailizer::Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
 		MonoScriptComponent* pScriptedComponent = (MonoScriptComponent*)data;
-		out << YAML::Key << "Properties";
-		out << YAML::BeginMap;
-		out << YAML::Key << "m_Script" << YAML::Value << pScriptedComponent->m_Script.AssetUUID();
-		out << YAML::Key << "ScriptData" << YAML::Value << YAML::BeginMap;
+		auto properties = node["Properties"];
+		properties.Set(YAML::Node(YAML::NodeType::Map));
+		properties["m_Script"].Set(uint64_t(pScriptedComponent->m_Script.AssetUUID()));
+		auto scriptData = properties["ScriptData"];
+		scriptData.Set(YAML::Node(YAML::NodeType::Map));
 
 		MonoScript* pScript = pScriptedComponent->m_Script.GetImmediate(&m_pSerializers->GetEngine()->GetAssetManager());
 		if (pScript)
@@ -33,20 +34,18 @@ namespace Glory
 			{
 				const ScriptProperty& prop = props[i];
 				const TypeData* pType = Reflect::GetTyeData(prop.m_TypeHash);
-				m_pSerializers->SerializeProperty(prop.m_Name, pType, &pScriptedComponent->m_ScriptData.m_Buffer[prop.m_RelativeOffset], out);
+				m_pSerializers->SerializeProperty(prop.m_Name, pType, &pScriptedComponent->m_ScriptData.m_Buffer[prop.m_RelativeOffset], scriptData);
 			}
 		}
-
-		out << YAML::EndMap << YAML::EndMap;
 	}
 
-	void ScriptedComponentSerailizer::Deserialize(void* data, uint32_t typeHash, YAML::Node& object)
+	void ScriptedComponentSerailizer::Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node)
 	{
-		YAML::Node scriptNode = object["m_Script"];
-		YAML::Node scriptDataNode = object["ScriptData"];
+		auto scriptNode = node["m_Script"];
+		auto scriptDataNode = node["ScriptData"];
 
 		MonoScriptComponent* pScriptedComponent = (MonoScriptComponent*)data;
-		pScriptedComponent->m_Script.SetUUID(scriptNode.as<uint64_t>());
+		pScriptedComponent->m_Script.SetUUID(scriptNode.As<uint64_t>());
 		MonoScript* pScript = pScriptedComponent->m_Script.GetImmediate(&m_pSerializers->GetEngine()->GetAssetManager());
 		if (pScript)
 		{

--- a/GloryEngine/Modules/GloryMonoScripting/ScriptedComponentSerializer.h
+++ b/GloryEngine/Modules/GloryMonoScripting/ScriptedComponentSerializer.h
@@ -11,7 +11,7 @@ namespace Glory
         virtual ~ScriptedComponentSerailizer();
 
     private:
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, YAML::Emitter& out) override;
-        virtual void Deserialize(void* data, uint32_t typeHash, YAML::Node& object) override;
+        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
 	};
 }

--- a/GloryEngine/Modules/GloryMonoScripting/ScriptedComponentSerializer.h
+++ b/GloryEngine/Modules/GloryMonoScripting/ScriptedComponentSerializer.h
@@ -11,7 +11,7 @@ namespace Glory
         virtual ~ScriptedComponentSerailizer();
 
     private:
-        virtual void Serialize(const std::string& name, void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
+        virtual void Serialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
         virtual void Deserialize(void* data, uint32_t typeHash, Utils::NodeValueRef node) override;
 	};
 }

--- a/GloryEngine/Utils/NodeRef.cpp
+++ b/GloryEngine/Utils/NodeRef.cpp
@@ -40,6 +40,26 @@ namespace Glory::Utils
 		Node() = node;
 	}
 
+	void NodeValueRef::SetMap()
+	{
+		Node() = YAML::Node(YAML::NodeType::Map);
+	}
+
+	void NodeValueRef::SetSequence()
+	{
+		Node() = YAML::Node(YAML::NodeType::Sequence);
+	}
+
+	void NodeValueRef::SetNull()
+	{
+		Node() = YAML::Node(YAML::NodeType::Null);
+	}
+
+	void NodeValueRef::SetScalar()
+	{
+		Node() = YAML::Node(YAML::NodeType::Scalar);
+	}
+
 	void NodeValueRef::PushBack(YAML::Node& node)
 	{
 		Node().push_back(node);
@@ -170,8 +190,47 @@ namespace Glory::Utils
 		return FindNode(m_RootNode, m_Path);
 	}
 
+	InMemoryYAML::InMemoryYAML()
+		: m_RootNode(), m_ParsingFailed(false)
+	{}
+
+	InMemoryYAML::InMemoryYAML(const char* data)
+	{
+		m_ParsingFailed = false;
+		try
+		{
+			m_RootNode = YAML::Load(data);
+		}
+		catch (const std::exception&)
+		{
+			m_ParsingFailed = true;
+		}
+	}
+
+	NodeRef InMemoryYAML::RootNodeRef()
+	{
+		return NodeRef(m_RootNode);
+	}
+
+	NodeValueRef InMemoryYAML::operator[](const std::filesystem::path& path)
+	{
+		return RootNodeRef()[path];
+	}
+
+	std::string InMemoryYAML::ToString()
+	{
+		YAML::Emitter out;
+		out << m_RootNode;
+		return out.c_str();
+	}
+
+	bool InMemoryYAML::ParsingFailed() const
+	{
+		return m_ParsingFailed;
+	}
+
 	YAMLFileRef::YAMLFileRef()
-		: m_FilePath(), m_RootNode()
+		: m_FilePath(), InMemoryYAML()
 	{
 	}
 
@@ -204,15 +263,5 @@ namespace Glory::Utils
 	void YAMLFileRef::ChangePath(const std::filesystem::path& newPath)
 	{
 		m_FilePath = newPath;
-	}
-
-	NodeRef YAMLFileRef::RootNodeRef()
-	{
-		return NodeRef(m_RootNode);
-	}
-
-	NodeValueRef YAMLFileRef::operator[](const std::filesystem::path& path)
-	{
-		return RootNodeRef()[path];
 	}
 }

--- a/GloryEngine/Utils/NodeRef.h
+++ b/GloryEngine/Utils/NodeRef.h
@@ -4,6 +4,9 @@
 
 namespace Glory::Utils
 {
+	/**
+	 * @brief Reference to a node value in a YAML document
+	 */
 	struct NodeValueRef
 	{
 	public:
@@ -52,6 +55,11 @@ namespace Glory::Utils
 		}
 
 		void Set(YAML::Node& node);
+		
+		void SetMap();
+		void SetSequence();
+		void SetNull();
+		void SetScalar();
 
 		template<typename T>
 		void PushBack(const T& value)
@@ -107,6 +115,9 @@ namespace Glory::Utils
 		const std::filesystem::path m_Path;
 	};
 
+	/**
+	 * @brief Reference to a node in a YAML document
+	 */
 	struct NodeRef
 	{
 	public:
@@ -120,7 +131,31 @@ namespace Glory::Utils
 		NodeValueRef m_RootValueRef;
 	};
 
-	struct YAMLFileRef
+	/**
+	 * @brief YAML document held in memory
+	 */
+	struct InMemoryYAML
+	{
+	public:
+		InMemoryYAML();
+		InMemoryYAML(const char* data);
+
+		NodeRef RootNodeRef();
+		NodeValueRef operator[](const std::filesystem::path& path);
+
+		std::string ToString();
+
+		bool ParsingFailed() const;
+
+	protected:
+		YAML::Node m_RootNode;
+		bool m_ParsingFailed;
+	};
+
+	/**
+	 * @brief Reference to a YAML file
+	 */
+	struct YAMLFileRef : public InMemoryYAML
 	{
 	public:
 		YAMLFileRef();
@@ -132,11 +167,7 @@ namespace Glory::Utils
 
 		void ChangePath(const std::filesystem::path& newPath);
 
-		NodeRef RootNodeRef();
-		NodeValueRef operator[](const std::filesystem::path& path);
-
 	private:
-		YAML::Node m_RootNode;
 		std::filesystem::path m_FilePath;
 	};
 }


### PR DESCRIPTION
- Serialization code now uses `Utils::NodeValueRef`
- All serialization and deserialization functions now assume the passed node is the node serialize/deserialize to/from
- Fixed crash when a property is being deserialized from an invalid YAML node