### PR TITLE
Streamline text rendering process

### DIFF
--- a/GloryEngine/Engine/Core/FontData.h
+++ b/GloryEngine/Engine/Core/FontData.h
@@ -5,31 +5,37 @@
 
 namespace Glory
 {
-    class InternalTexture;
+    class AssetManager;
+    class TextureData;
 
     class FontData : public Resource
     {
     public:
         GLORY_API FontData();
         GLORY_API FontData(uint32_t height, std::vector<uint64_t>&& characterCodes,
-            std::vector<GlyphData>&& chars, InternalTexture* pTexture);
+            std::vector<GlyphData>&& chars);
         GLORY_API virtual ~FontData();
 
         GLORY_API uint32_t FontHeight() const;
         GLORY_API size_t GetGlyphIndex(uint64_t c) const;
         GLORY_API const GlyphData* GetGlyph(size_t index) const;
-        GLORY_API InternalTexture* GetGlyphTexture() const;
+        GLORY_API TextureData* GetGlyphTexture(AssetManager& assets) const;
+        GLORY_API void SetTexture(UUID texture);
+        GLORY_API void SetMaterial(UUID material);
+        GLORY_API UUID Texture();
+        GLORY_API UUID Material();
 
         GLORY_API void Serialize(BinaryStream& container) const override;
         GLORY_API void Deserialize(BinaryStream& container) override;
 
     private:
-        virtual void References(Engine*, std::vector<UUID>&) const override {}
+        void References(Engine* pEngine, std::vector<UUID>& references) const override;
 
     private:
         uint32_t m_FontHeight;
         std::vector<uint64_t> m_CharacterCodes;
         std::vector<GlyphData> m_Glyphs;
-        InternalTexture* m_pTexture;
+        UUID m_Texture;
+        UUID m_Material;
     };
 }

--- a/GloryEngine/Engine/Core/FontDataStructs.cpp
+++ b/GloryEngine/Engine/Core/FontDataStructs.cpp
@@ -9,15 +9,15 @@
 
 namespace Glory::Utils
 {
-	void GenerateTextMesh(MeshData* pMesh, FontData* pFontData, const TextRenderData& renderData, float textWrap)
+	void GenerateTextMesh(MeshData* pMesh, FontData* pFontData, const TextData& textData, float textWrap)
 	{
-		const std::string_view text = renderData.m_Text;
-		const glm::vec4& color = renderData.m_Color;
-		const float scale = renderData.m_Scale;
-		const Alignment alignment = renderData.m_Alignment;
-		textWrap = textWrap > 0.0f ? textWrap : renderData.m_TextWrap/scale;
+		const std::string_view text = textData.m_Text;
+		const glm::vec4& color = textData.m_Color;
+		const float scale = textData.m_Scale;
+		const Alignment alignment = textData.m_Alignment;
+		textWrap = textWrap > 0.0f ? textWrap : textData.m_TextWrap/scale;
 
-		if (!renderData.m_Append)
+		if (!textData.m_Append)
 		{
 			pMesh->ClearVertices();
 			pMesh->ClearIndices();
@@ -73,8 +73,8 @@ namespace Glory::Utils
 
 				if (!glyph) continue;
 
-				const float xpos = renderData.m_Offsets.x + writeX + glyph->Bearing.x * scale;
-				const float ypos = renderData.m_Offsets.y + writeY - (glyph->Size.y - glyph->Bearing.y) * scale;
+				const float xpos = textData.m_Offsets.x + writeX + glyph->Bearing.x * scale;
+				const float ypos = textData.m_Offsets.y + writeY - (glyph->Size.y - glyph->Bearing.y) * scale;
 
 				const float w = glyph->Size.x * scale;
 				const float h = glyph->Size.y * scale;

--- a/GloryEngine/Engine/Core/FontDataStructs.h
+++ b/GloryEngine/Engine/Core/FontDataStructs.h
@@ -3,10 +3,31 @@
 
 #include <vector>
 #include <glm/ext/vector_int2.hpp>
+#include <glm/vec2.hpp>
 #include <glm/vec4.hpp>
+
+#include <Reflection.h>
+
+REFLECTABLE_ENUM_NS(Glory, Alignment, Left, Center, Right)
 
 namespace Glory
 {
+	struct TextData
+	{
+		/* Settings */
+		bool m_TextDirty;
+		float m_Scale;
+		Alignment m_Alignment;
+		float m_TextWrap;
+
+		/* Text */
+		std::string m_Text;
+		glm::vec4 m_Color;
+
+		glm::vec2 m_Offsets{};
+		bool m_Append{ false };
+	};
+
 	struct GlyphData
 	{
 		uint64_t Code;
@@ -16,12 +37,11 @@ namespace Glory
 		glm::vec4 Coords;
 	};
 
-	struct TextRenderData;
 	class MeshData;
 	class FontData;
 
 	namespace Utils
 	{
-		void GenerateTextMesh(MeshData* pMesh, FontData* pFontData, const TextRenderData& renderData, float textWrap=0.0f);
+		void GenerateTextMesh(MeshData* pMesh, FontData* pFontData, const TextData& renderData, float textWrap=0.0f);
 	}
 }

--- a/GloryEngine/Engine/Core/RenderData.h
+++ b/GloryEngine/Engine/Core/RenderData.h
@@ -5,8 +5,6 @@
 #include <glm/glm.hpp>
 #include <ReflectGen.h>
 
-REFLECTABLE_ENUM_NS(Glory, Alignment, Left, Center, Right)
-
 namespace Glory
 {
 	class MeshData;
@@ -31,37 +29,10 @@ namespace Glory
 
 		// World matrices
 		glm::mat4 m_World;
-		//size_t m_NumInstances;
-		//
+
 		// Material
 		UUID m_MaterialID;
 		LayerMask m_LayerMask;
 		bool m_DepthWrite{ true };
-	};
-
-	struct TextRenderData
-	{
-		/* Font */
-		UUID m_FontID;
-		UUID m_SceneID;
-		UUID m_ObjectID;
-		bool m_TextDirty;
-
-		/* Settings */
-		float m_Scale;
-		Alignment m_Alignment;
-		float m_TextWrap;
-
-		/* Text */
-		std::string m_Text;
-		glm::vec4 m_Color;
-
-		/* World matrix */
-		glm::mat4 m_World;
-
-		LayerMask m_LayerMask;
-
-		glm::vec2 m_Offsets{};
-		bool m_Append{ false };
 	};
 }

--- a/GloryEngine/Engine/Core/RenderFrame.h
+++ b/GloryEngine/Engine/Core/RenderFrame.h
@@ -75,9 +75,6 @@ namespace Glory
 		void Reset();
 
 	public:
-		//std::vector<RenderData> ObjectsToRender;
-		//std::vector<TextRenderData> TextsToRender;
-		//std::vector<RenderData> ObjectsToRenderLate;
 		std::vector<CameraRef> ActiveCameras;
 		std::vector<std::pair<glm::ivec2, UUID>> Picking;
 		FrameData<LightData> ActiveLights;

--- a/GloryEngine/Engine/Core/RendererModule.cpp
+++ b/GloryEngine/Engine/Core/RendererModule.cpp
@@ -151,23 +151,6 @@ namespace Glory
 		OnSubmitDynamic(renderData);
 	}
 
-	void RendererModule::SubmitDynamic(TextRenderData&& renderData)
-	{
-		ProfileSample s{ &m_pEngine->Profiler(), "RendererModule::Submit(TextRenderData)" };
-
-		const UUID pipelineID = TextPipelineID();
-		/* Can't render anything without a pipeline */
-		if (!pipelineID) return;
-
-		auto& iter = std::find_if(m_DynamicPipelineRenderDatas.begin(), m_DynamicPipelineRenderDatas.end(),
-			[pipelineID](const PipelineBatch& data) { return data.m_PipelineID == pipelineID; });
-		PipelineBatch& pipelineRenderData = iter == m_DynamicPipelineRenderDatas.end() ?
-			m_DynamicPipelineRenderDatas.emplace_back(pipelineID) : *iter;
-
-		pipelineRenderData.m_Texts.emplace_back(std::move(renderData));
-		pipelineRenderData.m_Dirty = true;
-	}
-
 	void RendererModule::SubmitLate(RenderData&& renderData)
 	{
 		ProfileSample s{ &m_pEngine->Profiler(), "RendererModule::SubmitLate(RenderData)" };
@@ -739,7 +722,6 @@ namespace Glory
 		m_Meshes.clear();
 		m_UniqueMeshOrder.clear();
 		m_UniqueMaterials.clear();
-		m_Texts.clear();
 		m_Dirty = true;
 	}
 }

--- a/GloryEngine/Engine/Core/RendererModule.h
+++ b/GloryEngine/Engine/Core/RendererModule.h
@@ -98,7 +98,6 @@ namespace Glory
 		std::unordered_map<UUID, PipelineMeshBatch> m_Meshes;
 		std::vector<UUID> m_UniqueMeshOrder;
 		std::vector<UUID> m_UniqueMaterials;
-		std::vector<TextRenderData> m_Texts;
 		bool m_Dirty;
 	};
 
@@ -114,7 +113,6 @@ namespace Glory
 		void UpdateStatic(UUID pipelineID, UUID meshID, UUID objectID, glm::mat4 world);
 		void UnsubmitStatic(UUID pipelineID, UUID meshID, UUID objectID);
 		void SubmitDynamic(RenderData&& renderData);
-		void SubmitDynamic(TextRenderData&& renderData);
 		void SubmitLate(RenderData&& renderData);
 		void Submit(CameraRef camera);
 		size_t Submit(const glm::ivec2& pickPos, UUID cameraID);
@@ -167,7 +165,6 @@ namespace Glory
 
 	protected:
 		virtual void OnSubmitDynamic(const RenderData& renderData) {}
-		virtual void OnSubmitDynamic(const TextRenderData& renderData) {}
 		virtual void OnSubmit(CameraRef camera) {}
 		virtual void OnSubmit(const LightData& light) {}
 

--- a/GloryEngine/Engine/Core/SceneManager.cpp
+++ b/GloryEngine/Engine/Core/SceneManager.cpp
@@ -248,6 +248,7 @@ namespace Glory
 		m_pComponentTypesInstance->RegisterInvokaction<Spin>(Glory::Utils::ECS::InvocationType::Update, SpinSystem::OnUpdate);
 
 		/* Text Renderer */
+		m_pComponentTypesInstance->RegisterInvokaction<TextComponent>(Glory::Utils::ECS::InvocationType::OnDisableDraw, TextSystem::OnDisableDraw);
 		m_pComponentTypesInstance->RegisterInvokaction<TextComponent>(Glory::Utils::ECS::InvocationType::Draw, TextSystem::OnDraw);
 		m_pComponentTypesInstance->RegisterReferencesCallback<TextComponent>(TextSystem::GetReferences);
 

--- a/GloryEngine/Engine/Core/TextSystem.h
+++ b/GloryEngine/Engine/Core/TextSystem.h
@@ -17,6 +17,7 @@ namespace Glory
     class TextSystem
     {
     public:
+        static void OnDisableDraw(Utils::ECS::EntityRegistry* pRegistry, Utils::ECS::EntityID entity, TextComponent& pComponent);
         static void OnDraw(Utils::ECS::EntityRegistry* pRegistry, Utils::ECS::EntityID entity, TextComponent& pComponent);
         static void GetReferences(const Utils::ECS::BaseTypeView* pTypeView, std::vector<UUID>& references);
     };

--- a/GloryEngine/Modules/GloryClusteredRenderer/Assets/Shaders/Text_Frag.shader
+++ b/GloryEngine/Modules/GloryClusteredRenderer/Assets/Shaders/Text_Frag.shader
@@ -2,13 +2,7 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(std430, binding = 2) readonly buffer ObjectData
-{
-	mat4 model;
-	mat4 view;
-	mat4 proj;
-	uvec4 ObjectID;
-} Object;
+#include "internal/ObjectData.glsl"
 
 layout(binding = 0) uniform sampler2D texSampler;
 

--- a/GloryEngine/Modules/GloryClusteredRenderer/Assets/Shaders/Text_Vert.shader
+++ b/GloryEngine/Modules/GloryClusteredRenderer/Assets/Shaders/Text_Vert.shader
@@ -2,13 +2,7 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(std430, binding = 2) readonly buffer ObjectData
-{
-	mat4 model;
-	mat4 view;
-	mat4 proj;
-	uvec4 ObjectID;
-} Object;
+#include "internal/ObjectData.glsl"
 
 layout(location = 0) in vec2 inPosition;
 layout(location = 1) in vec3 inColor;
@@ -20,7 +14,7 @@ layout(location = 2) out vec2 fragTexCoord;
 
 void main()
 {
-	gl_Position = Object.proj * Object.view * Object.model * vec4(inPosition, 0.0, 1.0);
+	gl_Position = Object.proj*Object.view*Object.model*vec4(inPosition, 0.0, 1.0);
 	outNormal = Object.model * vec4(0.0, 0.0, 1.0, 0.0);
 	fragTexCoord = inTexCoord;
 	outColor = vec4(inColor, 1.0);

--- a/GloryEngine/Modules/GloryClusteredRenderer/ClusteredRendererModule.h
+++ b/GloryEngine/Modules/GloryClusteredRenderer/ClusteredRendererModule.h
@@ -73,6 +73,8 @@ namespace Glory
 		void GenerateClusterSSBO(Buffer* pBuffer, CameraRef camera);
 		void GenerateDomeSamplePointsSSBO(GPUResourceManager* pResourceManager, uint32_t size);
 
+		void RenderBatches(const std::vector<PipelineBatch>& batches, const glm::mat4& view, const glm::mat4& projection);
+
 		void ShadowMapsPass(CameraRef camera, const RenderFrame& frameData);
 		void RenderShadows(size_t lightIndex, const RenderFrame& frameData);
 		//void RenderShadow(size_t lightIndex, const RenderFrame& frameData, const RenderData& objectToRender);

--- a/GloryEngine/Modules/GloryOverlayConsole/OverlayConsoleModule.cpp
+++ b/GloryEngine/Modules/GloryOverlayConsole/OverlayConsoleModule.cpp
@@ -261,10 +261,9 @@ namespace Glory
 			m_pInputTextBracketMesh.reset(new MeshData(4, sizeof(VertexPosColorTex),
 				{ AttributeType::Float2, AttributeType::Float3, AttributeType::Float2 }));
 
-			TextRenderData textData;
+			TextData textData;
 			textData.m_Color = glm::vec4(1.0f);
 			textData.m_Text = "]";
-			textData.m_FontID = consoleFont;
 			textData.m_TextWrap = 0.0f;
 			textData.m_Alignment = Alignment::Left;
 			textData.m_Scale = textScale;
@@ -279,10 +278,9 @@ namespace Glory
 			m_pInputTextCursorMesh.reset(new MeshData(4, sizeof(VertexPosColorTex),
 				{ AttributeType::Float2, AttributeType::Float3, AttributeType::Float2 }));
 
-			TextRenderData textData;
+			TextData textData;
 			textData.m_Color = glm::vec4(1.0f);
 			textData.m_Text = "|";
-			textData.m_FontID = consoleFont;
 			textData.m_TextWrap = 0.0f;
 			textData.m_Alignment = Alignment::Left;
 			textData.m_Scale = textScale;
@@ -303,10 +301,9 @@ namespace Glory
 
 			for (size_t i = 0; i < lastLine - firstLine; ++i)
 			{
-				TextRenderData textData;
+				TextData textData;
 				textData.m_Color = console.LineColor(firstLine + i);
 				textData.m_Text = console.Line(firstLine + i);
-				textData.m_FontID = consoleFont;
 				textData.m_TextWrap = 0.0f;
 				textData.m_Alignment = Alignment::Left;
 				textData.m_Scale = textScale;
@@ -320,10 +317,9 @@ namespace Glory
 
 		if (m_InputTextDirty && m_CursorPos > 0)
 		{
-			TextRenderData textData;
+			TextData textData;
 			textData.m_Color = glm::vec4(1.0f);
 			textData.m_Text = m_ConsoleInput;
-			textData.m_FontID = consoleFont;
 			textData.m_TextWrap = 0.0f;
 			textData.m_Alignment = Alignment::Left;
 			textData.m_Scale = textScale;
@@ -369,7 +365,7 @@ namespace Glory
 		object.Model = glm::translate(glm::identity<glm::mat4>(), glm::vec3(0.0f, windowHeight + animatedConsoleHeight - textStart, 0.0f));
 		pMaterial->SetObjectData(object);
 
-		InternalTexture* pTextureData = pFont->GetGlyphTexture();
+		TextureData* pTextureData = pFont->GetGlyphTexture(m_pEngine->GetAssetManager());
 		if (!pTextureData) return;
 
 		Texture* pTexture = pGPUResourceManager->CreateTexture((TextureData*)pTextureData);

--- a/GloryEngine/Modules/GloryUIRenderer/UIDocument.cpp
+++ b/GloryEngine/Modules/GloryUIRenderer/UIDocument.cpp
@@ -171,15 +171,15 @@ namespace Glory
 		return m_Projection;
 	}
 
-	MeshData* UIDocument::GetTextMesh(const TextRenderData& data, FontData* pFont)
+	MeshData* UIDocument::GetTextMesh(UUID objectID, const TextData& data, FontData* pFont)
 	{
-		auto iter = m_pTextMeshes.find(data.m_ObjectID);
+		auto iter = m_pTextMeshes.find(objectID);
 		const bool exists = iter != m_pTextMeshes.end();
 		if (!exists)
 		{
 			MeshData* pMesh = new MeshData(data.m_Text.size() * 4, sizeof(VertexPosColorTex),
 				{ AttributeType::Float2, AttributeType::Float3, AttributeType::Float2 });
-			iter = m_pTextMeshes.emplace(data.m_ObjectID, pMesh).first;
+			iter = m_pTextMeshes.emplace(objectID, pMesh).first;
 		}
 
 		if (data.m_TextDirty || !exists)

--- a/GloryEngine/Modules/GloryUIRenderer/UIDocument.h
+++ b/GloryEngine/Modules/GloryUIRenderer/UIDocument.h
@@ -16,7 +16,7 @@ namespace Glory
 	class MeshData;
 	class FontData;
 	class GraphicsModule;
-	struct TextRenderData;
+	struct TextData;
 
 	/** @brief Renderable copy of a UI document */
 	class UIDocument
@@ -36,7 +36,7 @@ namespace Glory
 		GLORY_API glm::mat4& Projection();
 		GLORY_API const glm::mat4& Projection() const;
 
-		GLORY_API MeshData* GetTextMesh(const TextRenderData& data, FontData* pFont);
+		GLORY_API MeshData* GetTextMesh(UUID objectID, const TextData& data, FontData* pFont);
 
 		GLORY_API void SetRenderTexture(RenderTexture* pTexture);
 

--- a/GloryEngine/Modules/GloryUIRenderer/UISystems.cpp
+++ b/GloryEngine/Modules/GloryUIRenderer/UISystems.cpp
@@ -179,6 +179,7 @@ namespace Glory
 		GraphicsModule* pGraphics = pEngine->GetMainModule<GraphicsModule>();
 		GPUResourceManager* pResourceManager = pGraphics->GetResourceManager();
 		AssetManager& assets = pEngine->GetAssetManager();
+		const UUID objectID = pDocument->EntityUUID(entity);
 
 		const UITransform& transform = pRegistry->GetComponent<UITransform>(entity);
 		const glm::vec2 size{ transform.m_Width, transform.m_Height };
@@ -189,9 +190,7 @@ namespace Glory
 
 		Constraints::ProcessConstraint(pComponent.m_Scale, size, transform.m_ParentSize, screenSize);
 
-		TextRenderData textData;
-		textData.m_FontID = pComponent.m_Font.AssetUUID();
-		textData.m_ObjectID = entity;
+		TextData textData;
 		textData.m_Text = pComponent.m_Text;
 		textData.m_TextDirty = pComponent.m_Dirty;
 		textData.m_Scale = float(pComponent.m_Scale);
@@ -202,7 +201,7 @@ namespace Glory
 
 		FontData* pFont = pComponent.m_Font.Get(&assets);
 		if (!pFont) return;
-		MeshData* pMeshData = pDocument->GetTextMesh(textData, pFont);
+		MeshData* pMeshData = pDocument->GetTextMesh(objectID, textData, pFont);
 		Mesh* pMesh = pResourceManager->CreateMesh(pMeshData);
 
 		const uint32_t height = pFont->FontHeight();
@@ -231,7 +230,7 @@ namespace Glory
 		pMaterial->SetProperties(pEngine);
 		pMaterial->SetObjectData(object);
 
-		InternalTexture* pTextureData = pFont->GetGlyphTexture();
+		TextureData* pTextureData = pFont->GetGlyphTexture(assets);
 		if (!pTextureData) return;
 
 		Texture* pTexture = pResourceManager->CreateTexture((TextureData*)pTextureData);


### PR DESCRIPTION
Removed TextRenderData and its dedicated submit function, added some steps to the font importer to generate a default material and include the image and texture as sub assets. Text system now uses regular Submit calls to render.